### PR TITLE
Either and exception as deferables

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,6 @@
                         :compiler {:output-to "target/tests.js"
                                    :optimizations :simple
                                    :pretty-print true}}]}
-
   :profiles {:dev {:dependencies [[speclj "3.1.0"]
                                   [com.keminglabs/cljx "0.5.0" :exclusions [org.clojure/clojure]]
                                   [org.clojure/tools.namespace "0.2.7"]]

--- a/project.clj
+++ b/project.clj
@@ -6,8 +6,7 @@
             :url "http://opensource.org/licenses/BSD-2-Clause"}
 
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2629"]]
-
+                 [org.clojure/clojurescript "0.0-2760"]]
   :source-paths ["target/src" "src/clj"]
 
   :deploy-repositories {"releases" :clojars

--- a/spec/cats/monad/either_spec.cljx
+++ b/spec/cats/monad/either_spec.cljx
@@ -17,6 +17,10 @@
     (s/should= 1 (either/from-either (either/right 1)))
     (s/should= nil (either/from-either (either/left))))
 
+  (s/it "Test IDeref"
+    (s/should= 1 @(either/left 1))
+    (s/should= 1 @(either/right 1)))
+
   (s/it "Test predicates"
     (let [m1 (either/right 1)]
       (s/should (either/either? m1))

--- a/spec/cats/monad/exception_spec.cljx
+++ b/spec/cats/monad/exception_spec.cljx
@@ -22,6 +22,10 @@
       (s/should= e (exc/from-failure (exc/try-on (throw e))))
       (s/should= e (exc/from-failure (exc/try-on e)))))
 
+  (s/it "Test IDeref"
+    (s/should= 1 @(exc/success 1))
+    (s/should= 1 @(exc/failure 1)))
+
   #+cljs
   (s/it "Basic operations with cljs."
     (let [e (js/Error. "test")]

--- a/spec/cats/monad/identity_spec.cljx
+++ b/spec/cats/monad/identity_spec.cljx
@@ -13,6 +13,9 @@
             [cats.core :as m]))
 
 (s/describe "identity-monad"
+  (s/it "Test IDeref"
+    (s/should= 1 @(id/identity 1)))
+
   (s/it "Test fmap"
     (s/should= (id/identity 2)
                (m/fmap inc (id/identity 1))))

--- a/spec/cats/monad/maybe_spec.cljx
+++ b/spec/cats/monad/maybe_spec.cljx
@@ -23,6 +23,10 @@
     (s/should= (p/get-value (maybe/just 1)) 1)
     (s/should= (p/get-value (maybe/nothing)) nil))
 
+  (s/it "Test IDeref"
+    (s/should= nil @(maybe/nothing))
+    (s/should= 1 @(maybe/just 1)))
+
   (s/it "Test predicates"
     (let [m1 (maybe/just 1)]
       (s/should (maybe/maybe? m1))

--- a/src/cljx/cats/monad/either.cljx
+++ b/src/cljx/cats/monad/either.cljx
@@ -39,6 +39,16 @@
   (get-value [_] v)
 
   #+clj
+  clojure.lang.IDeref
+  #+clj
+  (deref [_] v)
+
+  #+cljs
+  IDeref
+  #+cljs
+  (-deref [_] v)
+
+  #+clj
   Object
   #+clj
   (equals [self other]
@@ -62,6 +72,16 @@
   proto/Context
   (get-context [_] either-monad)
   (get-value [_] v)
+
+  #+clj
+  clojure.lang.IDeref
+  #+clj
+  (deref [_] v)
+
+  #+cljs
+  IDeref
+  #+cljs
+  (-deref [_] v)
 
   #+clj
   Object

--- a/src/cljx/cats/monad/either.cljx
+++ b/src/cljx/cats/monad/either.cljx
@@ -1,5 +1,5 @@
-;; Copyright (c) 2014, Andrey Antukh
-;; Copyright (c) 2014, Alejandro Gómez
+;; Copyright (c) 2014-2015 Andrey Antukh <niwi@niwi.be>
+;; Copyright (c) 2014-2015 Alejandro Gómez
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/src/cljx/cats/monad/exception.cljx
+++ b/src/cljx/cats/monad/exception.cljx
@@ -52,6 +52,16 @@
   (get-value [_] v)
 
   #+clj
+  clojure.lang.IDeref
+  #+clj
+  (deref [_] v)
+
+  #+cljs
+  IDeref
+  #+cljs
+  (-deref [_] v)
+
+  #+clj
   Object
   #+clj
   (equals [self other]
@@ -76,6 +86,16 @@
   proto/Context
   (get-context [_] exception-monad)
   (get-value [_] e)
+
+  #+clj
+  clojure.lang.IDeref
+  #+clj
+  (deref [_] e)
+
+  #+cljs
+  IDeref
+  #+cljs
+  (-deref [_] e)
 
   #+clj
   Object

--- a/src/cljx/cats/monad/exception.cljx
+++ b/src/cljx/cats/monad/exception.cljx
@@ -1,5 +1,5 @@
-;; Copyright (c) 2014, Andrey Antukh
-;; Copyright (c) 2014, Alejandro Gómez
+;; Copyright (c) 2014-2015 Andrey Antukh <niwi@niwi.be>
+;; Copyright (c) 2014-2015 Alejandro Gómez
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/src/cljx/cats/monad/identity.cljx
+++ b/src/cljx/cats/monad/identity.cljx
@@ -40,6 +40,16 @@
   (get-value [_] v)
 
   #+clj
+  clojure.lang.IDeref
+  #+clj
+  (deref [_] v)
+
+  #+cljs
+  IDeref
+  #+cljs
+  (-deref [_] v)
+
+  #+clj
   Object
   #+clj
   (equals [_ other]

--- a/src/cljx/cats/monad/identity.cljx
+++ b/src/cljx/cats/monad/identity.cljx
@@ -1,5 +1,5 @@
-;; Copyright (c) 2014, Andrey Antukh
-;; Copyright (c) 2014, Alejandro Gómez
+;; Copyright (c) 2014-2015 Andrey Antukh <niwi@niwi.be>
+;; Copyright (c) 2014-2015 Alejandro Gómez
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/src/cljx/cats/monad/maybe.cljx
+++ b/src/cljx/cats/monad/maybe.cljx
@@ -39,6 +39,16 @@
   (get-value [_] v)
 
   #+clj
+  clojure.lang.IDeref
+  #+clj
+  (deref [_] v)
+
+  #+cljs
+  IDeref
+  #+cljs
+  (-deref [_] v)
+
+  #+clj
   Object
   #+clj
   (equals [self other]
@@ -62,6 +72,16 @@
   proto/Context
   (get-context [_] maybe-monad)
   (get-value [_] nil)
+
+  #+clj
+  clojure.lang.IDeref
+  #+clj
+  (deref [_] nil)
+
+  #+cljs
+  IDeref
+  #+cljs
+  (-deref [_] nil)
 
   #+clj
   Object

--- a/src/cljx/cats/monad/maybe.cljx
+++ b/src/cljx/cats/monad/maybe.cljx
@@ -1,5 +1,5 @@
-;; Copyright (c) 2014, Andrey Antukh
-;; Copyright (c) 2014, Alejandro Gómez
+;; Copyright (c) 2014-2015 Andrey Antukh <niwi@niwi.be>
+;; Copyright (c) 2014-2015 Alejandro Gómez
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This is a really little change that may make slightly more simple way to extract the value from context. 

IDeref implementation is added to an subset of supported monads because not all are semantically compatible.