### PR TITLE
Semigroup and Monoid

### DIFF
--- a/doc/cats.adoc
+++ b/doc/cats.adoc
@@ -10,18 +10,18 @@ image:logo.png[cats logo]
 
 == Introduction
 
-Category Theory abstractions for Clojure.
+Category Theory and algebraic abstractions for Clojure.
 
 == Rationale
 
 The main motivations for writting this library are:
 
-* The existing libraries does not have support for ClojureScript.
-* We do not intend to write a little haskell inside the clojure. We have adopted a
+* The existing libraries do not have support for ClojureScript.
+* We do not intend to write a little haskell inside Clojure. We have adopted a
   practical and clojure like approach, always with corectness in mind.
 * We do not like viral/copyleft like licenses and with difference with other libraries
   cats is licensed under BSD (2 clauses) license.
-* We do not intend implement only monads. Other category theory abstractions are also
+* We do not intend implement only monads. Other category theory and algebraic abstractions are also
   first class in cats.
 
 
@@ -81,10 +81,13 @@ We will use the _Maybe_ for the example snippets, because it has support for all
 the abstractions and it is very easy to understand. You can read more about it in the next
 section of this documentation.
 
+=== Semigroup
+
+=== Monoid
 
 === Functor
 
-Let's start with the functor. The Functor represents some sort of "computational context", and the
+Let's dive into the functor. The Functor represents some sort of "computational context", and the
 abstraction consists of one unique function: *fmap*.
 
 .Signature of *fmap* function

--- a/doc/cats.adoc
+++ b/doc/cats.adoc
@@ -74,7 +74,7 @@ git clone https://github.com/funcool/cats
 
 == User Guide
 
-This section introduces almost all the category theory abstractions that the _cats_ library
+This section introduces almost all the category theory and algebraic abstractions that the _cats_ library
 supports.
 
 We will use the _Maybe_ for the example snippets, because it has support for all
@@ -83,7 +83,48 @@ section of this documentation.
 
 === Semigroup
 
+A semigroup is an algebraic structure with an associative binary operation (`mappend`). Most of the builtin collections
+form a semigroup because its associative binary operation is analogous to Clojure's `into`.
+
+[source, clojure]
+----
+(require '[cats.core :as m])
+
+(m/mappend [1 2 3] [4 5 6])
+;; => [1 2 3 4 5 6]
+----
+
+Given that the values it contains form a Semigroup, we can `mappend` multiple _Maybe_ values.
+
+[source, clojure]
+----
+(require '[cats.core :as m])
+(require '[cats.monad.maybe :as maybe])
+
+(m/mappend (maybe/just [1 2 3])
+           (maybe/just [4 5 6]))
+;; => #<Just [1 2 3 4 5 6]>
+----
+
 === Monoid
+
+A Monoid is a Semigroup with an identity element (`mempty`). For the collection types the `mempty`
+function is analogous to Clojure's `empty`.
+
+Given that the values it contains form a Semigroup, we can `mappend` multiple _Maybe_, Nothing being
+the identity element.
+
+[source, clojure]
+----
+(require '[cats.core :as m])
+(require '[cats.monad.maybe :as maybe])
+
+(m/mappend (maybe/just [1 2 3])
+           (maybe/nothing)
+           (maybe/just [4 5 6])
+           (maybe/nothing))
+;; => #<Just [1 2 3 4 5 6]>
+----
 
 === Functor
 
@@ -110,7 +151,7 @@ wrapper is any type that acts as "Box" and implements the `Context` and `Functor
 (require '[cats.monad.maybe :as maybe])
 
 (maybe/just 2)
-;; => #<Just [2]>
+;; => #<Just 2>
 ----
 
 The `just` function is a constructor of Just type that is part of Maybe monad.
@@ -123,7 +164,7 @@ Let's see one example using *fmap* over *just* instance:
 (require '[cats.core :as m])
 
 (m/fmap inc (maybe/just 1))
-;; => #<Just [2]>
+;; => #<Just 2>
 ----
 
 The *Maybe* type also has another constructor: `nothing`. It represents the absence of a value.
@@ -224,10 +265,10 @@ can apply the returned greeter to any value without a defensive nil check:
 [source, clojure]
 ----
 (fapply (make-greeter "es") (just "Alex"))
-;; => #<Just [Hola Alex]>
+;; => #<Just "Hola Alex">
 
 (fapply (make-greeter "en") (just "Alex"))
-;; => #<Just [Hello Alex]>
+;; => #<Just "Hello Alex">
 
 (fapply (make-greeter "it") (just "Alex"))
 ;; => #<Nothing >
@@ -243,7 +284,7 @@ Examples:
 (require '[cats.monad.maybe :as maybe])
 
 (pure maybe/maybe-monad 5)
-;; => #<Just [5]>
+;; => #<Just 5>
 ----
 
 If you do not understand the purpose of the *pure* function, the next section
@@ -274,7 +315,7 @@ that in a monad, the function is a responsible for wrapping a returned value in 
 ----
 (m/bind (maybe/just 1)
         (fn [v] (maybe/just (inc v))))
-;; => #<Just [2]>
+;; => #<Just 2>
 ----
 
 One of the key features of the bind function is that any computation executed within the context of
@@ -288,7 +329,7 @@ what that container is, you can use `return` or `pure` functions:
 (m/bind (maybe/just 1)
         (fn [v]
           (m/return (inc v))))
-;; => #<Just [2]>
+;; => #<Just 2>
 ----
 
 The `return` or `pure` functions, when called with one argument, try to use the dynamic scope context
@@ -355,7 +396,7 @@ we can implement a generic `fmap` for the type _a (b Any)_, we'll call it fmap2:
 ; combined functor is a vector of Maybe values that could
 ; contain a value of any type.
 (fmap2 inc [(maybe/just 1) (maybe/just 2)])
-;;=> [#<Just [2]> #<Just [3]>]
+;;=> [#<Just 2> #<Just 3>]
 ----
 
 However, monads don't compose as nicely as functors do. We have to actually implement
@@ -389,7 +430,7 @@ return a reified MonadTrans:
 
 (m/with-monad maybe-state
   (state/run-state (m/return 42) {}))
-;; => #<Just [#<Pair [42 {}]>]>
+;; => #<Just #<Pair [42 {}]>>
 ----
 
 As we can see in the example below, the return of the `maybe-state` monad creates a stateful
@@ -424,7 +465,7 @@ _cats_, implements two types:
 [source, clojure]
 ----
 (maybe/just 1)
-;; => #<Just [1]>
+;; => #<Just 1>
 
 (maybe/nothing)
 ;; => #<Nothing >

--- a/src/cljx/cats/builtin.cljx
+++ b/src/cljx/cats/builtin.cljx
@@ -142,7 +142,7 @@
   (reify
     proto/Semigroup
     (mappend [_ sv sv']
-      (s/union sv sv'))
+      (s/union sv (set sv')))
 
     proto/Monoid
     (mempty [_]

--- a/src/cljx/cats/builtin.cljx
+++ b/src/cljx/cats/builtin.cljx
@@ -46,6 +46,14 @@
 
 (def sequence-monad
   (reify
+    proto/Semigroup
+    (mappend [_ sv sv']
+      (concat sv sv'))
+
+    proto/Monoid
+    (mempty [_]
+      (lazy-seq []))
+
     proto/Functor
     (fmap [_ f v]
       (map f v))
@@ -85,6 +93,14 @@
 
 (def vector-monad
   (reify
+    proto/Semigroup
+    (mappend [_ sv sv']
+      (into sv sv'))
+
+    proto/Monoid
+    (mempty [_]
+      [])
+
     proto/Functor
     (fmap [_ f v]
       (vec (map f v)))
@@ -124,6 +140,14 @@
 
 (def set-monad
   (reify
+    proto/Semigroup
+    (mappend [_ sv sv']
+      (s/union sv sv'))
+
+    proto/Monoid
+    (mempty [_]
+      #{})
+
     proto/Functor
     (fmap [_ self f]
       (set (map f self)))

--- a/src/cljx/cats/core.cljx
+++ b/src/cljx/cats/core.cljx
@@ -82,6 +82,17 @@
 ;; Context-aware funcionts
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defn mempty
+  []
+  (let [ctx (get-current-context)]
+    (p/mempty ctx)))
+
+(defn mappend
+  [& svs]
+  {:pre [(not (empty? svs))]}
+  (let [ctx (get-current-context (first svs))]
+    (reduce (partial p/mappend ctx) svs)))
+
 (defn pure
   "Given any value v, return it wrapped in
   default/effect free context.

--- a/src/cljx/cats/monad/maybe.cljx
+++ b/src/cljx/cats/monad/maybe.cljx
@@ -32,7 +32,8 @@
       (maybe/just 1)
       ;; => #<Just [1]>
   "
-  (:require [cats.protocols :as proto]))
+  (:require [cats.protocols :as proto]
+            [cats.core :as m]))
 
 (declare maybe-monad)
 
@@ -183,6 +184,18 @@
 (def ^{:no-doc true}
   maybe-monad
   (reify
+    proto/Semigroup
+    (mappend [_ mv mv']
+      (cond
+        (nothing? mv) mv'
+        (nothing? mv') mv
+        :else (just (m/mappend (proto/extract mv)
+                               (proto/extract mv')))))
+
+    proto/Monoid
+    (mempty [_]
+      (nothing))
+
     proto/Functor
     (fmap [_ f mv]
       (if (nothing? mv)

--- a/src/cljx/cats/protocols.cljx
+++ b/src/cljx/cats/protocols.cljx
@@ -43,13 +43,21 @@
   Maybe monad."
   (get-context [_] "Get the monad instance for curent value."))
 
+(defprotocol Semigroup
+  "A structure with an associative binary operation."
+  (mappend [s sv sv'] "An associative addition operation."))
+
+(defprotocol Monoid
+  "A Semigroup which has an identity element for is associative binary operation."
+  (mempty [s] "The identity element for the given monoid."))
+
 (defprotocol Extract
   "A type class responsible of extract the
   value from a monad context."
   (extract [mv] "Extract the value from monad context."))
 
 (defprotocol Functor
-  "The Functor abstraction."
+  "A data type that can be mapped over without altering its context."
   (fmap [ftor f fv] "Applies function f to the value(s) inside the context of the functor fv."))
 
 (defprotocol Applicative
@@ -69,7 +77,7 @@
 (defprotocol MonadZero
   "A complement abstraction for monad that
   supports the notion of an identity element."
-  (mzero [m] "The identity element for `ctx`."))
+  (mzero [m] "The identity element for the given monadzero."))
 
 (defprotocol MonadPlus
   "A complement abstraction for Monad that

--- a/test/cats/builtin_spec.cljx
+++ b/test/cats/builtin_spec.cljx
@@ -23,6 +23,15 @@
     (t/is (= (p/extract nil) nil))))
 
 (t/deftest vector-monad
+  (t/testing "Forms a semigroup"
+    (t/is (= [1 2 3 4 5]
+             (m/mappend [1 2 3] [4 5]))))
+
+  (t/testing "Forms a monoid"
+    (t/is (= [1 2 3]
+             (m/with-monad b/vector-monad
+               (m/mappend [1 2 3] (m/mempty))))))
+
   (t/testing "The first monad law: left identity"
     (t/is (= [1 2 3 4 5]
              (m/>>= [0 1 2 3 4]
@@ -46,6 +55,15 @@
   (let [val->lazyseq (fn [x] (lazy-seq [x]))
         s (val->lazyseq 2)]
 
+  (t/testing "Forms a semigroup"
+    (t/is (= [1 2 3 4 5]
+             (m/mappend (lazy-seq [1 2 3]) (lazy-seq [4 5])))))
+
+  (t/testing "Forms a monoid"
+    (t/is (= [1 2 3]
+             (m/with-monad b/sequence-monad
+               (m/mappend (lazy-seq [1 2 3]) (m/mempty))))))
+
     (t/testing "The first monad law: left identity"
       (t/is (= s (m/with-monad b/sequence-monad
                    (m/>>= (m/return 2)
@@ -66,6 +84,15 @@
 
 
 (t/deftest set-monad
+  (t/testing "Forms a semigroup"
+    (t/is (= #{1 2 3 4 5}
+             (m/mappend #{1 2 3} #{4 5}))))
+
+  (t/testing "Forms a monoid"
+    (t/is (= #{1 2 3}
+             (m/with-monad b/set-monad
+               (m/mappend #{1 2 3} (m/mempty))))))
+
   (t/testing "The first monad law: left identity"
     (t/is (= #{2} (m/with-monad b/set-monad
                     (m/>>= (m/return 2)

--- a/test/cats/core_spec.cljx
+++ b/test/cats/core_spec.cljx
@@ -27,6 +27,7 @@
              (m/mlet [i [1 2 3 4 5]
                       :when (> i 2)]
                (m/return i)))))
+
   (t/testing "The body runs in an implicit do"
     (t/is (= (maybe/just 3)
              (m/mlet [i (maybe/just 2)
@@ -78,7 +79,6 @@
       (t/is (= (maybe/nothing)
                (monad+ (maybe/just 1) (maybe/nothing)))))
 
-    #+clj
     (t/testing "It can lift a function to a Monad Transformer"
       (let [maybe-sequence-monad (maybe/maybe-transformer b/sequence-monad)]
         (t/is (= [(maybe/just 1) (maybe/just 2)

--- a/test/cats/monad/maybe_spec.cljx
+++ b/test/cats/monad/maybe_spec.cljx
@@ -38,6 +38,15 @@
       (t/is (= (m/fmap inc m1) (maybe/just 2)))
       (t/is (= (m/fmap inc m2) (maybe/nothing)))))
 
+  (t/testing "Forms a Semigroup when its values form a Semigroup"
+    (t/is (= (maybe/just [1 2 3 4 5])
+             (m/mappend (maybe/just [1 2 3]) (maybe/just [4 5])))))
+
+  (t/testing "Its identity element is Nothing"
+    (t/is (= (maybe/nothing)
+             (m/with-monad maybe/maybe-monad
+               (m/mempty)))))
+
   (t/testing "The first monad law: left identity"
     (t/is (= (maybe/just 2)
              (m/>>= (p/mreturn maybe/maybe-monad 2) maybe/just))))


### PR DESCRIPTION
@niwibe take a look, there's more things we could add but I'm in for merging this and adding additional stuff later. I wanted to add semigroups because I'm going to implement a "validation" monad, hopefully today :)

Ideas for the future:
- Semigroup and Monoid instance for hash-maps
- A `cats.monoid` namespace for common monoids such as Product, Sum, All, and Any