### PR TITLE
Replace `condp =` with `case`

### DIFF
--- a/src/cljx/cats/core.cljx
+++ b/src/cljx/cats/core.cljx
@@ -234,7 +234,7 @@
     (throw (IllegalArgumentException. "bindings has to be a vector with even number of elements.")))
   (->> (reverse (partition 2 bindings))
        (reduce (fn [acc [l r]]
-                 (condp = l
+                 (case l
                    :let  `(let ~r ~acc)
                    :when `(bind (guard ~r)
                                 (fn [~(gensym)] ~acc))


### PR DESCRIPTION
Since `:let` and `:when` are both compile-time literals, it makes sense to use `case` instead of `condp =`.
> The benefit of case is that unlike cond and condp, it is not a sequential search for a match – the match is O(1).
— Alex Miller, ["Learning Clojure #15: case"][1]


[1]: http://tech.puredanger.com/2010/05/30/learning-clojure-15-case/