### PR TITLE
Add branch-left and branch-right

### DIFF
--- a/src/cats/monad/either.cljc
+++ b/src/cats/monad/either.cljc
@@ -234,12 +234,14 @@
   (branch e lf right))
 
 (defn branch-right
-  "Given an either value and a function, if the either is a
+  "Either-specific synonym for #'cats.core/bind
+
+  Given an either value and a function, if the either is a
   right, apply the function to the value it contains; if the
   either is a left, return it."
   [e rf]
   {:pre [(either? e)]}
-  (branch e left rf))
+  (m/bind e rf))
 
 (def lefts
   "Given a collection of eithers, return only the values that are left."

--- a/src/cats/monad/either.cljc
+++ b/src/cats/monad/either.cljc
@@ -225,6 +225,22 @@
     (lf (m/extract e))
     (rf (m/extract e))))
 
+(defn branch-left
+  "Given an either value and a function, if the either is a
+  left, apply the function to the value it contains; if the
+  either is a right, return it."
+  [e lf]
+  {:pre [(either? e)]}
+  (branch e lf right))
+
+(defn branch-right
+  "Given an either value and a function, if the either is a
+  right, apply the function to the value it contains; if the
+  either is a left, return it."
+  [e rf]
+  {:pre [(either? e)]}
+  (branch e left rf))
+
 (def lefts
   "Given a collection of eithers, return only the values that are left."
   (partial filter left?))

--- a/test/cats/monad/either_spec.cljc
+++ b/test/cats/monad/either_spec.cljc
@@ -95,6 +95,18 @@
     (t/is (= "OH NO" (either/branch l s/upper-case inc)))
     (t/is (= 43 (either/branch r s/upper-case inc)))))
 
+(t/deftest branch-left-test
+  (let [l (either/left "oh no")
+        r (either/right 42)]
+    (t/is (= "OH NO" (either/branch-left l s/upper-case)))
+    (t/is (= r (either/branch-left r s/upper-case)))))
+
+(t/deftest branch-right-test
+  (let [l (either/left "oh no")
+        r (either/right 42)]
+    (t/is (= l (either/branch-right l inc)))
+    (t/is (= 43 (either/branch-right r inc)))))
+
 
 (t/deftest filtering-test
   (let [l1 (either/left "oh no")


### PR DESCRIPTION
When using [cats][1], specifically [the either monad][2], I often find myself writing code like:

```clojure
(branch either-value
  (fn [value]
    (comment "Handle a left value"))
  ;; Pass a right value
  right)
```

For this case, I thought it would be better if `(branch e f right)` were abstracted away, and that's precisely what I've done in [`#'cats.monad.either/branch-left`][3].

In the interest of symmetry and completeness, I also implemented [`#'cats.monad.either/branch-right`][4], which is effectively an either-specific synonym of [`#'cats.core/bind`][5].

The functionality is loosely based on ideas in the [either package][6] for Haskell.
See also: [`Data.Either.Combinators`][7]


[1]: https://github.com/funcool/cats
[2]: https:/github.com/funcool/cats/blob/master/src/cats/monad/either.cljc
[3]: https://github.com/yurrriq/cats/blob/1c21682052ceff254545e23cbd4015ef74b071f8/src/cats/monad/either.cljc#L228-L234
[4]: https://github.com/yurrriq/cats/blob/1c21682052ceff254545e23cbd4015ef74b071f8/src/cats/monad/either.cljc#L236-L242
[5]: https://github.com/funcool/cats/blob/5accd7c937d1cdea9391a828dcdd41e41b6e83f8/src/cats/core.cljc#L117-L139
[6]: https://hackage.haskell.org/package/either-4.4.1
[7]: https://hackage.haskell.org/package/either-4.4.1/docs/Data-Either-Combinators.html
