### PR TITLE
Extend object with exception-monad context

### DIFF
--- a/src/cats/builtin.cljc
+++ b/src/cats/builtin.cljc
@@ -27,6 +27,7 @@
   "Clojure(Script) built-in types extensions."
   (:require [clojure.set :as s]
             [cats.monad.maybe :as maybe]
+            [cats.monad.exception :as exc]
             [cats.protocols :as proto]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -204,3 +205,14 @@
    (extend-type clojure.lang.PersistentArrayMap
      proto/Context
      (get-context [_] map-monoid)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Object as Exception monad
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(extend-type Object
+  proto/Context
+  (get-context [_] exc/exception-monad)
+
+  proto/Extract
+  (extract [it] it))

--- a/src/cats/monad/exception.cljc
+++ b/src/cats/monad/exception.cljc
@@ -176,10 +176,12 @@
 (defn failure?
   "Return true if `v` is an instance of
   the Failure type."
-  [v]
-  (or (instance? Failure v)
-      (and (satisfies? proto/Context v)
-           (instance? Throwable v))))
+  ([v] (failure? v false))
+  ([v strict]
+   (or (instance? Failure v)
+       (and (satisfies? proto/Context v)
+            (instance? Throwable v)
+            (not strict)))))
 
 (defn exception?
   "Return true in case of `v` is instance
@@ -300,4 +302,6 @@
     (mbind [_ s f]
       (if (success? s)
         (f (proto/extract s))
-        s))))
+        (if (failure? s true)
+          s
+          (failure s))))))

--- a/src/cats/monad/exception.cljc
+++ b/src/cats/monad/exception.cljc
@@ -169,13 +169,17 @@
   "Return true if `v` is an instance of
   the Success type."
   [v]
-  (instance? Success v))
+  (or (instance? Success v)
+      (and (satisfies? proto/Context v)
+           (not (instance? Throwable v)))))
 
 (defn failure?
   "Return true if `v` is an instance of
   the Failure type."
   [v]
-  (instance? Failure v))
+  (or (instance? Failure v)
+      (and (satisfies? proto/Context v)
+           (instance? Throwable v))))
 
 (defn exception?
   "Return true in case of `v` is instance


### PR DESCRIPTION
This allows use use plain objects in `mlet` that may help to user adapt third party libraries.  Plain objects are coerced to success types of exception monad. And exceptions are coerced to failure instances.

Obviously for use it, you should import the cats.builtins. Without importing it, success? and failture? predicates will not work with plain objects:

```clojure
;; before import cats.builtin
(exc/success? {})
;; => false

(exc/failure? (ex-info "foobar" {}))
;; => false

;; After import cats.builtin

(exc/success? {})
;; => true

(exc/failure? (ex-info "foobar" {}))
;; => true
```

So using plain objects in mlet is only available when user explicitly imports `cats.builtin` ns.

```clojure
(m/mlet [a 1
         b 2]
  (m/return (+ a b)))
;; => #<Success [3] >
```

**This PR is not ready because I should resolve some little issue with exception coercion, currently it does not works as expected and I should add some tests.**

What do you thing about this?