### PR TITLE
Code cleaning & Performance improvements

### DIFF
--- a/src/cats/applicative/validation.cljc
+++ b/src/cats/applicative/validation.cljc
@@ -157,14 +157,12 @@
     proto/Foldable
     (foldl [_ f z mv]
       (if (ok? mv)
-        (m/with-monad (proto/get-context mv)
-          (f z (proto/extract mv)))
+        (f z (proto/extract mv))
         z))
 
     (foldr [_ f z mv]
       (if (ok? mv)
-        (m/with-monad (proto/get-context mv)
-          (f (proto/extract mv) z))
+        (f (proto/extract mv) z)
         z))
 
     proto/Applicative

--- a/src/cats/context.cljc
+++ b/src/cats/context.cljc
@@ -1,0 +1,75 @@
+;; Copyright (c) 2014-2015 Andrey Antukh <niwi@niwi.nz>
+;; Copyright (c) 2014-2015 Alejandro Gómez <alejandro@dialelo.com>
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions
+;; are met:
+;;
+;; 1. Redistributions of source code must retain the above copyright
+;;    notice, this list of conditions and the following disclaimer.
+;; 2. Redistributions in binary form must reproduce the above copyright
+;;    notice, this list of conditions and the following disclaimer in the
+;;    documentation and/or other materials provided with the distribution.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+;; IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+;; OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+;; IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+;; INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+;; NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+;; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+;; THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+;; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+(ns cats.context
+  "A context management macros."
+  (:require [cats.protocols :as p]))
+
+(def ^{:dynamic true :no-doc true}
+  *context* nil)
+
+#?(:clj
+   (defmacro with-context
+     "Set current context to specific monad."
+     [ctx & body]
+     `(cond
+        (satisfies? p/MonadTrans ~ctx)
+        (binding [*context* ~ctx]
+          ~@body)
+
+        (satisfies? p/MonadTrans *context*)
+        (do ~@body)
+
+        :else
+        (binding [*context* ~ctx]
+          ~@body))))
+
+#?(:clj
+   (defmacro with-monad
+     "Semantic alias for `with-context`."
+     [ctx & body]
+     `(with-context ~ctx
+        ~@body)))
+
+(defn get-current
+  "Get current context or obtain it from
+  the provided instance."
+  {:no-doc true}
+  ([] (get-current nil))
+  ([default]
+   (cond
+     (not (nil? *context*))
+     *context*
+
+     (satisfies? p/Context default)
+     (p/get-context default)
+
+     (satisfies? p/Monad default)
+     default
+
+     :else
+     (throw (#?(:clj IllegalArgumentException.
+                :cljs js/Error.)
+             "You are using return/pure/mzero function without context.")))))

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -517,11 +517,13 @@
 (defn foldr
   "Perform a right-associative fold on the data structure."
   [f z xs]
-  (-> (p/get-context xs)
-      (p/foldr f z xs)))
+  (let [ctx (p/get-context xs)]
+    (with-context ctx
+      (p/foldr ctx f z xs))))
 
 (defn foldl
   "Perform a right-associative fold on the data structure."
   [f z xs]
-  (-> (p/get-context xs)
-      (p/foldl f z xs)))
+  (let [ctx (p/get-context xs)]
+    (with-context ctx
+      (p/foldl ctx f z xs))))

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -46,6 +46,12 @@
      `(ctx/with-context ~ctx
         ~@body)))
 
+(defn get-current-context
+  "Alias to cats.context/get-current for backward compatibility."
+  {:deprecated true}
+  ([] (ctx/get-current nil))
+  ([default] (ctx/get-current default)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Context-aware funcionts
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -36,12 +36,13 @@
   (:refer-clojure :exclude [when unless filter sequence]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Context Management
+;; Backward compatiblity aliases.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 #?(:clj
    (defmacro with-monad
      "Alias to `with-context` for backward compatibility."
+     {:deprecated true}
      [ctx & body]
      `(ctx/with-context ~ctx
         ~@body)))

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -26,7 +26,7 @@
 (ns cats.core
   "Category Theory abstractions for Clojure"
   #?(:cljs
-     (:require-macros [cats.core :refer (with-monad mlet)]))
+     (:require-macros [cats.core :refer (with-monad with-context mlet)]))
   (:require [cats.protocols :as p])
   (:refer-clojure :exclude [when unless filter sequence]))
 
@@ -39,7 +39,7 @@
   *context* nil)
 
 #?(:clj
-   (defmacro with-monad
+   (defmacro with-context
      "Set current context to specific monad."
      [ctx & body]
      `(cond
@@ -53,6 +53,13 @@
         :else
         (binding [*context* ~ctx]
           ~@body))))
+
+#?(:clj
+   (defmacro with-monad
+     "Alias to `with-context`."
+     [ctx & body]
+     `(with-context ~ctx
+        ~@body)))
 
 (defn ^{:no-doc true}
   get-current-context

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -108,7 +108,7 @@
 
   Example:
 
-      (with-monad either/either-monad
+      (with-context either/either-monad
         (pure 1)
       ;; => #<Right [1]>
   "
@@ -134,7 +134,7 @@
   compose operations with `bind` function."
   [mv f]
   (let [ctx (get-current-context mv)]
-    (with-monad ctx
+    (with-context ctx
       (p/mbind ctx mv f))))
 
 (defn mzero
@@ -379,7 +379,7 @@
   [mvs]
   {:pre [(not-empty mvs)]}
   (let [ctx (get-current-context (first mvs))]
-    (with-monad ctx
+    (with-context ctx
       (reduce (fn [mvs mv]
                 (mlet [v mv
                        vs mvs]
@@ -444,7 +444,7 @@
       ;=> <Nothing>
   "
   [p mv]
-  (with-monad (get-current-context mv)
+  (with-context (get-current-context mv)
     (mlet [v mv
            :when (p v)]
           (return v))))
@@ -492,7 +492,7 @@
 (defn >=>
   "Left-to-right composition of monads."
   [mf mg x]
-  (with-monad (get-current-context mf)
+  (with-context (get-current-context mf)
     (mlet [a (mf x)
            b (mg a)]
           (return b))))
@@ -501,7 +501,7 @@
   "Right-to-left composition of monads.
   Same as `>=>` with its first two arguments flipped."
   [mg mf x]
-  (with-monad (get-current-context mf)
+  (with-context (get-current-context mf)
     (mlet [a (mf x)
            b (mg a)]
           (return b))))

--- a/src/cats/monad/either.cljc
+++ b/src/cats/monad/either.cljc
@@ -37,8 +37,7 @@
       (either/left 1)
       ;; => #<Left [1]>
   "
-  (:require [cats.protocols :as proto]
-            [cats.core :as m]))
+  (:require [cats.protocols :as proto]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Type constructor and functions

--- a/src/cats/monad/either.cljc
+++ b/src/cats/monad/either.cljc
@@ -169,14 +169,12 @@
     proto/Foldable
     (foldl [_ f z mv]
       (if (right? mv)
-        (m/with-monad (proto/get-context mv)
-          (f z (proto/extract mv)))
+        (f z (proto/extract mv))
         z))
 
     (foldr [_ f z mv]
       (if (right? mv)
-        (m/with-monad (proto/get-context mv)
-          (f (proto/extract mv) z))
+        (f (proto/extract mv) z)
         z))))
 
 

--- a/src/cats/monad/either.cljc
+++ b/src/cats/monad/either.cljc
@@ -37,7 +37,7 @@
       (either/left 1)
       ;; => #<Left [1]>
   "
-  (:require [cats.protocols :as proto]))
+  (:require [cats.protocols :as p]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Type constructor and functions
@@ -46,10 +46,10 @@
 (declare either-monad)
 
 (deftype Right [v]
-  proto/Context
+  p/Context
   (get-context [_] either-monad)
 
-  proto/Extract
+  p/Extract
   (extract [_] v)
 
   #?(:clj clojure.lang.IDeref
@@ -67,17 +67,17 @@
          (with-out-str (print [v])))])
 
   #?@(:cljs
-       [cljs.core/IEquiv
-        (-equiv [_ other]
-                (if (instance? Right other)
-                  (= v (.-v other))
-                  false))]))
+      [cljs.core/IEquiv
+       (-equiv [_ other]
+         (if (instance? Right other)
+           (= v (.-v other))
+           false))]))
 
 (deftype Left [v]
-  proto/Context
+  p/Context
   (get-context [_] either-monad)
 
-  proto/Extract
+  p/Extract
   (extract [_] v)
 
   #?(:clj clojure.lang.IDeref
@@ -95,11 +95,11 @@
          (with-out-str (print [v])))])
 
   #?@(:cljs
-       [cljs.core/IEquiv
-        (-equiv [_ other]
-                (if (instance? Left other)
-                  (= v (.-v other))
-                  false))]))
+      [cljs.core/IEquiv
+       (-equiv [_ other]
+         (if (instance? Left other)
+           (= v (.-v other))
+           false))]))
 
 (alter-meta! #'->Right assoc :private true)
 (alter-meta! #'->Left assoc :private true)
@@ -130,8 +130,8 @@
   "Return true in case of `v` is instance
   of Either monad."
   [v]
-  (if (satisfies? proto/Context v)
-    (identical? (proto/get-context v) either-monad)
+  (if (satisfies? p/Context v)
+    (identical? (p/get-context v) either-monad)
     false))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -141,22 +141,22 @@
 (def ^{:no-doc true}
   either-monad
   (reify
-    proto/Functor
+    p/Functor
     (fmap [_ f s]
       (if (right? s)
         (right (f (.-v s)))
         s))
 
-    proto/Applicative
+    p/Applicative
     (pure [_ v]
       (right v))
 
     (fapply [m af av]
       (if (right? af)
-        (proto/fmap m (.-v af) av)
+        (p/fmap m (.-v af) av)
         af))
 
-    proto/Monad
+    p/Monad
     (mreturn [_ v]
       (right v))
 
@@ -165,15 +165,15 @@
         (f (.-v s))
         s))
 
-    proto/Foldable
+    p/Foldable
     (foldl [_ f z mv]
       (if (right? mv)
-        (f z (proto/extract mv))
+        (f z (p/extract mv))
         z))
 
     (foldr [_ f z mv]
       (if (right? mv)
-        (f (proto/extract mv) z)
+        (f (p/extract mv) z)
         z))))
 
 
@@ -185,19 +185,19 @@
   "The Either transformer constructor."
   [inner-monad]
   (reify
-    proto/Monad
+    p/Monad
     (mreturn [_ v]
-      (proto/mreturn inner-monad (right v)))
+      (p/mreturn inner-monad (right v)))
 
     (mbind [_ mv f]
-      (proto/mbind inner-monad
-                   mv
-                   (fn [either-v]
-                     (if (left? either-v)
-                       (proto/mreturn inner-monad either-v)
-                       (f (proto/extract either-v))))))
+      (p/mbind inner-monad
+               mv
+               (fn [either-v]
+                 (if (left? either-v)
+                   (p/mreturn inner-monad either-v)
+                   (f (p/extract either-v))))))
 
-    proto/MonadTrans
+    p/MonadTrans
     (base [_]
       either-monad)
 
@@ -205,10 +205,10 @@
       inner-monad)
 
     (lift [m mv]
-      (proto/mbind inner-monad
-                   mv
-                   (fn [v]
-                     (proto/mreturn inner-monad (right v)))))))
+      (p/mbind inner-monad
+               mv
+               (fn [v]
+                 (p/mreturn inner-monad (right v)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Utility functions
@@ -221,8 +221,8 @@
   [e lf rf]
   {:pre [(either? e)]}
   (if (left? e)
-    (lf (proto/extract e))
-    (rf (proto/extract e))))
+    (lf (p/extract e))
+    (rf (p/extract e))))
 
 (defn branch-left
   "Given an either value and a function, if the either is a
@@ -241,7 +241,7 @@
   [e rf]
   {:pre [(either? e)]}
   (let [context either-monad]
-    (proto/mbind context e rf)))
+    (p/mbind context e rf)))
 
 (def lefts
   "Given a collection of eithers, return only the values that are left."
@@ -264,5 +264,5 @@
   [e]
   {:pre [(either? e)]}
   (if (left? e)
-    (right (proto/extract e))
-    (left (proto/extract e))))
+    (right (p/extract e))
+    (left (p/extract e))))

--- a/src/cats/monad/exception.cljc
+++ b/src/cats/monad/exception.cljc
@@ -53,15 +53,12 @@
   That is because when you will dereference the
   failure instance, it will reraise the containing
   exception."
-  #?(:clj
-     (:require [cats.protocols :as p]
-               [cats.core :refer [with-monad]]))
 
-  #?@(:cljs
-      [(:require [cats.protocols :as p])
-
-       (:require-macros [cats.monad.exception :refer [try-on]]
-                        [cats.core :refer [with-monad]])]))
+  (:require [cats.protocols :as p]
+            #?(:clj [cats.context :as ctx]
+               :cljs [cats.context :as ctx :include-macros true]))
+  #?(:cljs
+     (:require-macros [cats.monad.exception :refer (try-on)])))
 
 (defn throw-exception
   [message]
@@ -231,7 +228,7 @@
   exec-try-or-recover
   [func recoverfn]
   (let [result (exec-try-on func)]
-    (with-monad exception-monad
+    (ctx/with-context exception-monad
       (if (failure? result)
         (recoverfn (.-e result))
         result))))

--- a/src/cats/monad/identity.cljc
+++ b/src/cats/monad/identity.cljc
@@ -25,7 +25,7 @@
 
 (ns cats.monad.identity
   "The Identity Monad."
-  (:require [cats.protocols :as proto])
+  (:require [cats.protocols :as p])
   (:refer-clojure :exclude [identity]))
 
 (declare identity-monad)
@@ -35,10 +35,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (deftype Identity [v]
-  proto/Context
+  p/Context
   (get-context [_] identity-monad)
 
-  proto/Extract
+  p/Extract
   (extract [_] v)
 
   #?(:clj clojure.lang.IDeref
@@ -56,11 +56,11 @@
          (str v))])
 
   #?@(:cljs
-       [cljs.core/IEquiv
-        (-equiv [_ other]
-                (if (instance? Identity other)
-                  (= v (.-v other))
-                  false))]))
+      [cljs.core/IEquiv
+       (-equiv [_ other]
+         (if (instance? Identity other)
+           (= v (.-v other))
+           false))]))
 
 (alter-meta! #'->Identity assoc :private true)
 
@@ -76,18 +76,18 @@
 (def ^{:no-doc true}
   identity-monad
   (reify
-    proto/Functor
+    p/Functor
     (fmap [_ f iv]
       (Identity. (f (.-v iv))))
 
-    proto/Applicative
+    p/Applicative
     (pure [_ v]
       (Identity. v))
 
     (fapply [_ af av]
       (Identity. ((.-v af) (.-v av))))
 
-    proto/Monad
+    p/Monad
     (mreturn [_ v]
       (Identity. v))
 
@@ -102,9 +102,9 @@
   "The Identity transformer constructor."
   [inner-monad]
   (reify
-    proto/Monad
+    p/Monad
     (mreturn [_ v]
-      (identity (proto/mreturn inner-monad v)))
+      (identity (p/mreturn inner-monad v)))
 
     (mbind [_ mv f]
       nil)))

--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -171,9 +171,9 @@
       (cond
         (nothing? mv) mv'
         (nothing? mv') mv
-        :else (just (p/mappend ctx
-                               (p/extract mv)
-                               (p/extract mv')))))
+        :else (just (let [mv (p/extract mv)
+                          mv' (p/extract mv')]
+                      (p/mappend (p/get-context mv) mv mv')))))
 
     p/Monoid
     (mempty [_]

--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -167,11 +167,12 @@
   maybe-monad
   (reify
     p/Semigroup
-    (mappend [_ mv mv']
+    (mappend [ctx mv mv']
       (cond
         (nothing? mv) mv'
         (nothing? mv') mv
-        :else (just (m/mappend (p/extract mv)
+        :else (just (p/mappend ctx
+                               (p/extract mv)
                                (p/extract mv')))))
 
     p/Monoid

--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -304,14 +304,17 @@
     (lazy-seq [])
     (lazy-seq [(p/extract m)])))
 
+(def ^{:private true :no-doc true}
+  +extract-just-xform+
+  (comp
+   (filter just?)
+   (map p/extract)))
+
 (defn cat-maybes
   "Given a collection of maybes, return a sequence of the values
   that the just's contain."
   [coll]
-  (let [xform (comp
-               (filter just?)
-               (map p/extract))]
-    (sequence xform coll)))
+  (sequence +extract-just-xform+ coll))
 
 (defn map-maybe
   "Given a maybe-returning function and a collection, map the function over

--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -286,7 +286,7 @@
   {:pre [(maybe? m)]}
   (if (nothing? m)
     default
-    (f (m/extract m))))
+    (f (p/extract m))))
 
 (defn seq->maybe
   "Given a collection, return a nothing if its empty or a just with its
@@ -303,14 +303,14 @@
   {:pre [(maybe? m)]}
   (if (nothing? m)
     (lazy-seq [])
-    (lazy-seq [(m/extract m)])))
+    (lazy-seq [(p/extract m)])))
 
 ;; TODO: use a transducer when we support 1.7.0+
 (defn cat-maybes
   "Given a collection of maybes, return a sequence of the values that the
    just's contain."
   [coll]
-  (map m/extract (filter just? coll)))
+  (map p/extract (filter just? coll)))
 
 (defn map-maybe
   "Given a maybe-returning function and a collection, map the function over

--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -305,12 +305,14 @@
     (lazy-seq [])
     (lazy-seq [(p/extract m)])))
 
-;; TODO: use a transducer when we support 1.7.0+
 (defn cat-maybes
-  "Given a collection of maybes, return a sequence of the values that the
-   just's contain."
+  "Given a collection of maybes, return a sequence of the values
+  that the just's contain."
   [coll]
-  (map p/extract (filter just? coll)))
+  (let [xform (comp
+               (filter just?)
+               (map p/extract))]
+    (sequence xform coll)))
 
 (defn map-maybe
   "Given a maybe-returning function and a collection, map the function over

--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -183,7 +183,7 @@
     (fmap [_ f mv]
       (if (nothing? mv)
         mv
-        (just (f (from-maybe mv)))))
+        (just (f (p/extract mv)))))
 
     p/Applicative
     (pure [_ v]
@@ -191,7 +191,7 @@
     (fapply [m af av]
       (if (nothing? af)
         af
-        (p/fmap m (from-maybe af) av)))
+        (p/fmap m (p/extract af) av)))
 
     p/Monad
     (mreturn [_ v]
@@ -199,7 +199,7 @@
     (mbind [_ mv f]
       (if (nothing? mv)
         mv
-        (f (from-maybe mv))))
+        (f (p/extract mv))))
 
     p/MonadZero
     (mzero [_]
@@ -247,7 +247,7 @@
                mv
                (fn [maybe-v]
                  (if (just? maybe-v)
-                   (f (from-maybe maybe-v))
+                   (f (p/extract maybe-v))
                    (p/mreturn inner-monad (nothing))))))
 
     p/MonadZero

--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -32,8 +32,7 @@
       (maybe/just 1)
       ;; => #<Just [1]>
   "
-  (:require [cats.protocols :as p]
-            [cats.core :as m]))
+  (:require [cats.protocols :as p]))
 
 (declare maybe-monad)
 

--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -214,14 +214,12 @@
     p/Foldable
     (foldl [_ f z mv]
       (if (just? mv)
-        (m/with-monad (p/get-context mv)
-          (f z (p/extract mv)))
+        (f z (p/extract mv))
         z))
 
     (foldr [_ f z mv]
       (if (just? mv)
-        (m/with-monad (p/get-context mv)
-          (f (p/extract mv) z))
+        (f (p/extract mv) z)
         z))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/cats/protocols.cljc
+++ b/src/cats/protocols.cljc
@@ -89,32 +89,6 @@
   supports the notion of addition."
   (mplus [m mv mv'] "An associative addition operation."))
 
-(defprotocol MonadState
-  "A specific case of Monad abstraction for
-  work with state in pure functional way."
-  (get-state [m] "Return the current state.")
-  (put-state [m newstate] "Update the state.")
-  (swap-state [m f] "Apply a function to the current state and update it."))
-
-(defprotocol MonadReader
-  "A specific case of Monad abstraction that
-  allows a read only access to an environment."
-  (ask [m] "Return the current environment.")
-  (local [m f reader] "Create a reader in a modified version of the environment."))
-
-(defprotocol MonadWriter
-  "A specific case of Monad abstraction that
-  allows emulate write operations in pure functional
-  way.
-
-  A great example is writing a log message."
-  (listen [m mv] "Given a writer, yield a (value, log) pair as a value.")
-  (tell [m v] "Add the given value to the log.")
-  (pass [m mv]
-    "Given a writer whose value is a pair with a function as its second element,
-     yield a writer which has the first element of the pair as the value and
-     the result of applying the aforementioned function to the log as the new log."))
-
 (defprotocol MonadTrans
   "A common abstraction for all monad transformers."
   (base [mt] "Return the base monad of this transformer.")


### PR DESCRIPTION
- Remove all unnecessary call forwarding through cats.core namespace.
- Cosmetic fixes such as indentation fixes or namespace aliases renames.
- Use transducers when we can.
- Improve naming.
- Some lightweight core reorganization