### PR TITLE
seq, Haskell-style

### DIFF
--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -148,7 +148,7 @@
   a result wrapped in context of same type of av context.
 
   This function is variadic, so it can be used like
-  a haskell style left-associative fapply."
+  a Haskell-style left-associative fapply."
   [af & avs]
   {:pre [(not (empty? avs))]}
   (let [ctx (ctx/get-current af)]
@@ -425,11 +425,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def <$>
-  "A haskell-style fmap alias."
+  "A Haskell-style fmap alias."
   fmap)
 
 (def <*>
-  "A haskell-style fapply alias."
+  "A Haskell-style fapply alias."
   fapply)
 
 (defn >>=

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -64,7 +64,7 @@
 
 (defn mappend
   [& svs]
-  {:pre [(not (empty? svs))]}
+  {:pre [(seq svs)]}
   (let [ctx (ctx/get-current (first svs))]
     (reduce (partial p/mappend ctx) svs)))
 
@@ -116,7 +116,7 @@
 
 (defn mplus
   [& mvs]
-  {:pre [(not (empty? mvs))]}
+  {:pre [(seq mvs)]}
   (let [ctx (ctx/get-current (first mvs))]
     (reduce (partial p/mplus ctx) mvs)))
 
@@ -150,7 +150,7 @@
   This function is variadic, so it can be used like
   a Haskell-style left-associative fapply."
   [af & avs]
-  {:pre [(not (empty? avs))]}
+  {:pre [(seq avs)]}
   (let [ctx (ctx/get-current af)]
     (reduce (partial p/fapply ctx) af avs)))
 


### PR DESCRIPTION
- Capitalization and hyphen usage was inconsistent w.r.t "Haskell-style"
- The [`empty?` docstring][1] suggests using `(seq x)` instead of `(not (empty? x))`.


[1]: https://github.com/clojure/clojure/blob/bdc752a7fefff5e63e0847836ae5e6d95f971c37/src/clj/clojure/core.clj#L5945