### PR TITLE
More style and docstring fixes

### DIFF
--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -69,18 +69,21 @@
     (reduce (partial p/mappend ctx) svs)))
 
 (defn pure
-  "Given any value v, return it wrapped in
-  default/effect free context.
+  "Given any value `v`, return it wrapped in
+  the default/effect-free context.
 
-  This is multiarity function that with arity pure/1
-  it uses the dynamic scope to resolve the current
+  This is a multi-arity function that with arity `pure/1`
+  uses the dynamic scope to resolve the current
   context. With `pure/2`, you can force a specific context
   value.
 
   Example:
 
       (with-context either/either-monad
-        (pure 1)
+        (pure 1))
+      ;; => #<Right [1]>
+
+      (pure either/either-monad 1)
       ;; => #<Right [1]>
   "
   ([v] (pure (ctx/get-current) v))

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -382,7 +382,7 @@
 (defn forseq
   "Same as mapseq but with the arguments in reverse order.
 
-  Let se a little example:
+  Let's see a little example:
 
       (m/forseq [2 3] maybe/just)
       ;; => <Just [[2 3]]>
@@ -436,7 +436,7 @@
   "Performs a Haskell-style left-associative
   bind.
 
-  Let see it in action:
+  Let's see it in action:
 
       (>>= (just 1) (comp just inc) (comp just inc))
       ;; => #<Just [3]>

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -257,10 +257,10 @@
 
 #?(:clj
    (defmacro curry
-     "Given either a fixed arity function or an arity and a function
-     yields another which is curried.
+     "Given either a fixed arity function or an arity and a function,
+     return another which is curried.
 
-     With inferred arity (function must have one fixed arity)
+     With inferred arity (function must have one fixed arity):
 
          (defn add2 [x y] (+ x y))
          (def cadd2 (curry add2))
@@ -271,7 +271,7 @@
          (cadd2 1 3)
          ;; => 4
 
-     With fixed arity:
+     With given arity:
 
          (def c+ (curry 3 +))
 
@@ -299,8 +299,7 @@
 
 #?(:clj
    (defmacro lift-m
-     "Lifts a function with the given fixed number of arguments to a
-     monadic context.
+     "Lift a function with a given fixed arity to a monadic context.
 
          (def monad+ (lift-m 2 +))
 
@@ -335,7 +334,7 @@
 
 #?(:clj
    (defmacro curry-lift-m
-     "Is a composition of curry and lift-m macros."
+     "Composition of `curry` and `lift-m`"
      [n f]
      `(curry ~n (lift-m ~n ~f))))
 

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -380,7 +380,7 @@
   (sequence (map mf coll)))
 
 (defn forseq
-  "Same as mapseq but with the arguments in reverse order.
+  "Same as `mapseq` but with the arguments flipped.
 
   Let's see a little example:
 
@@ -456,7 +456,7 @@
 
 (defn =<<
   "Same as the two argument version of `>>=` but with the
-  arguments interchanged."
+  arguments flipped."
   [f mv]
   (>>= mv f))
 

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -131,12 +131,12 @@
 
 (defn join
   "Remove one level of monadic structure.
-  This is same as that `(bind mv identity)`"
+  This is the same as `(bind mv identity)`."
   [mv]
   (bind mv identity))
 
 (defn fmap
-  "Apply a function `f` to the value inside functor `fv`,
+  "Apply a function `f` to the value wrapped in functor `fv`,
   preserving the context type."
   ([f]
    (fn [fv]

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -159,16 +159,18 @@
     (reduce (partial p/fapply ctx) af avs)))
 
 (defn when
-  "If the expression is true, returns the monadic value.
-  Otherwise, yields nil in a monadic context."
+  "Given an expression and a monadic value,
+  if the expression is logical true, return the monadic value.
+  Otherwise, return nil in a monadic context."
   ([b mv]
    (when (ctx/get-current mv) b mv))
   ([ctx b mv]
    (if b mv (return ctx nil))))
 
 (defn unless
-  "If the expression is false, returns the monadic value.
-  Otherwise, yields nil in a monadic context."
+  "Given an expression and a monadic value,
+  if the expression is not logical true, return the monadic value.
+  Otherwise, return nil in a monadic context."
   [b mv]
   (when-not b
     mv))

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -185,8 +185,8 @@
      let. This allows much easy composition of monadic
      computations.
 
-     Let see one example for understand how it works, this is
-     a code using bind for compose few number of operations:
+     Let's see an example to understand how it works.
+     This code uses bind to compose a few operations:
 
          (bind (just 1)
                (fn [a]
@@ -195,8 +195,8 @@
                            (return (* b 2))))))
          ;=> #<Just [4]>
 
-     Now see how this code can be more clear if you
-     are using mlet macro for do it:
+     Now see how this code can be made clearer
+     by using the mlet macro:
 
          (mlet [a (just 1)
                 b (just (inc a))]

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -187,9 +187,9 @@
 
 #?(:clj
    (defmacro mlet
-     "Monad composition macro that works like clojure
-     let. This allows much easy composition of monadic
-     computations.
+     "Monad composition macro that works like Clojure's
+     `let`. This facilitates much easier composition of
+     monadic computations.
 
      Let's see an example to understand how it works.
      This code uses bind to compose a few operations:

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -48,7 +48,7 @@
         ~@body)))
 
 (defn get-current-context
-  "Alias to cats.context/get-current for backward compatibility."
+  "Alias to `cats.context/get-current` for backward compatibility."
   {:deprecated true}
   ([] (ctx/get-current nil))
   ([default] (ctx/get-current default)))
@@ -87,7 +87,7 @@
   ([ctx v] (p/pure ctx v)))
 
 (defn return
-  "This is a monad version of pure and it works
+  "This is a monad version of `pure` and works
   identically to it."
   ([v] (return (ctx/get-current) v))
   ([ctx v] (p/mreturn ctx v)))
@@ -133,7 +133,7 @@
   (bind mv identity))
 
 (defn fmap
-  "Apply a function f to the value inside functor's fv
+  "Apply a function `f` to the value inside functor `fv`,
   preserving the context type."
   ([f]
    (fn [fv]
@@ -425,11 +425,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def <$>
-  "A Haskell-style fmap alias."
+  "A Haskell-style `fmap` alias."
   fmap)
 
 (def <*>
-  "A Haskell-style fapply alias."
+  "A Haskell-style `fapply` alias."
   fapply)
 
 (defn >>=

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -438,8 +438,7 @@
   fapply)
 
 (defn >>=
-  "Performs a Haskell-style left-associative
-  bind.
+  "Perform a Haskell-style left-associative bind.
 
   Let's see it in action:
 
@@ -452,8 +451,8 @@
    (reduce bind mv (cons f fs))))
 
 (defn >>
-  "Performs a Haskell-style left-associative bind,
-  ignoring the values produced by the monad computations."
+  "Perform a Haskell-style left-associative bind,
+  ignoring the values produced by the monadic computations."
   ([mv mv']
    (bind mv (fn [_] mv')))
   ([mv mv' & mvs]
@@ -483,7 +482,7 @@
       (return b))))
 
 (defn extract
-  "Generic function for unwrap/extract
+  "Generic function to unwrap/extract
   the inner value of a container."
   [v]
   (p/extract v))

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -96,16 +96,16 @@
   ([ctx v] (p/mreturn ctx v)))
 
 (defn bind
-  "Given a value inside monadic context `mv` and any function,
-  applies a function to value of mv.
+  "Given a monadic value `mv` and a function `f`,
+  apply `f` to the unwrapped value of `mv`.
 
       (bind (either/right 1) (fn [v]
                                (return (inc v))))
       ;; => #<Right [2]>
 
-  For convenience, you may prefer use a `mlet` macro
-  that add a beautiful, let like syntax for
-  compose operations with `bind` function."
+  For convenience, you may prefer to use the `mlet` macro,
+  which provides a beautiful, `let`-like syntax for
+  composing operations with the `bind` function."
   [mv f]
   (let [ctx (ctx/get-current mv)]
     (ctx/with-context ctx

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -364,9 +364,9 @@
               (reverse mvs)))))
 
 (defn mapseq
-  "Given a function that takes a value and puts it into a
-  monadic context, map it into the given collection
-  calling sequence on the results.
+  "Given a function `mf` that takes a value and puts it into a
+  monadic context, and a collection, map `mf` over the collection,
+  calling `sequence` on the results.
 
       (require '[cats.monad.maybe :as maybe])
       (require '[cats.core :as m])
@@ -405,12 +405,12 @@
   (mapseq mf vs))
 
 (defn filter
-  "Applies a predicate to a value in a `MonadZero` instance,
-  returning the identity element when the predicate yields false.
+  "Apply a predicate to a value in a `MonadZero` instance,
+  returning the identity element when the predicate does not hold.
 
-  Otherwise, returns the instance unchanged.
+  Otherwise, return the instance unchanged.
 
-      (require '[cats.monad.moaybe :as maybe])
+      (require '[cats.monad.maybe :as maybe])
       (require '[cats.core :as m])
 
       (m/filter (partial < 2) (maybe/just 3))

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -146,9 +146,10 @@
        (p/fmap f fv))))
 
 (defn fapply
-  "Given function inside af's context and value inside
-  av's context, applies the function to value and return
-  a result wrapped in context of same type of av context.
+  "Given a function wrapped in a monadic context `af`,
+  and a value wrapped in a monadic context `av`,
+  apply the unwrapped function to the unwrapped value
+  and return the result, wrapped in the same context as `av`.
 
   This function is variadic, so it can be used like
   a Haskell-style left-associative fapply."

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -36,7 +36,7 @@
   (:refer-clojure :exclude [when unless filter sequence]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Backward compatiblity aliases.
+;; Backward compatiblity aliases
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 #?(:clj
@@ -54,7 +54,7 @@
   ([default] (ctx/get-current default)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Context-aware funcionts
+;; Context-aware functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn mempty

--- a/test/cats/builtin_spec.cljc
+++ b/test/cats/builtin_spec.cljc
@@ -52,14 +52,14 @@
   (let [val->lazyseq (fn [x] (lazy-seq [x]))
         s (val->lazyseq 2)]
 
-  (t/testing "Forms a semigroup"
-    (t/is (= [1 2 3 4 5]
-             (m/mappend (lazy-seq [1 2 3]) (lazy-seq [4 5])))))
+    (t/testing "Forms a semigroup"
+      (t/is (= [1 2 3 4 5]
+               (m/mappend (lazy-seq [1 2 3]) (lazy-seq [4 5])))))
 
-  (t/testing "Forms a monoid"
-    (t/is (= [1 2 3]
-             (m/with-monad b/sequence-monad
-               (m/mappend (lazy-seq [1 2 3]) (m/mempty))))))
+    (t/testing "Forms a monoid"
+      (t/is (= [1 2 3]
+               (m/with-monad b/sequence-monad
+                 (m/mappend (lazy-seq [1 2 3]) (m/mempty))))))
 
     (t/testing "The first monad law: left identity"
       (t/is (= s (m/with-monad b/sequence-monad

--- a/test/cats/builtin_spec.cljc
+++ b/test/cats/builtin_spec.cljc
@@ -141,5 +141,4 @@
             result (m/foldr (partial foldr-fn state) '() (map identity [1 2 3 4]))]
         (t/is (= @state 0))
         (t/is (= 2 (first result)))
-        (t/is (= @state 1))))
-))
+        (t/is (= @state 1))))))

--- a/test/cats/core_spec.cljc
+++ b/test/cats/core_spec.cljc
@@ -67,7 +67,7 @@
 
 
 (t/deftest mapseq-tests
-  (t/testing "It works with maybe values"
+  (t/testing "It works with Maybe values"
     (t/is (= (m/mapseq maybe/just [1 2 3 4 5])
              (maybe/just [1 2 3 4 5])))
     (t/is (= (maybe/nothing)

--- a/test/cats/core_spec.cljc
+++ b/test/cats/core_spec.cljc
@@ -116,15 +116,15 @@
       (t/is (= (maybe/just 6)
                ((curry-monad+ (maybe/just 1)) (maybe/just 5))))))
 
-    (t/testing "It can lift a function to a Monad Transformer"
-      (let [maybe-sequence-monad (maybe/maybe-transformer b/sequence-monad)
-            monad+ (m/lift-m 2 add2)]
-        (t/is (= [(maybe/just 1) (maybe/just 2)
-                  (maybe/just 3) (maybe/just 4)
-                  (maybe/just 5) (maybe/just 6)]
-                 (m/with-monad maybe-sequence-monad
-                   (monad+ [(maybe/just 0) (maybe/just 2) (maybe/just 4)]
-                           [(maybe/just 1) (maybe/just 2)])))))))
+  (t/testing "It can lift a function to a Monad Transformer"
+    (let [maybe-sequence-monad (maybe/maybe-transformer b/sequence-monad)
+          monad+ (m/lift-m 2 add2)]
+      (t/is (= [(maybe/just 1) (maybe/just 2)
+                (maybe/just 3) (maybe/just 4)
+                (maybe/just 5) (maybe/just 6)]
+               (m/with-monad maybe-sequence-monad
+                 (monad+ [(maybe/just 0) (maybe/just 2) (maybe/just 4)]
+                         [(maybe/just 1) (maybe/just 2)])))))))
 
 (t/deftest filter-tests
   (t/testing "It can filter Maybe monadic values"


### PR DESCRIPTION
Before I get too far, I wanted to make another pull request. This is composed mostly of minor style fixes (like indentation) and grammatical edits in docstrings.

This PR covers all the tests, as well as the entirety of [`core.cljc`][1]

Some goals I had in making theses changes were:
- Proper English grammar
- Clarity and brevity
- Consistency (wrt capitalization and wording especially)
- Imperative language in docstrings, as described in [The Emacs Lisp Style Guide][2]


[1]: https://github.com/funcool/cats/blob/master/src/cats/core.cljc
[2]: https://github.com/bbatsov/emacs-lisp-style-guide#docstrings