### PR TITLE
WIP: Applicative and functor instances for monad transformers

### DIFF
--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -235,6 +235,25 @@
               #(p/fmap maybe-monad f %)
               fv))
 
+    p/Applicative
+    (pure [_ v]
+      (p/mreturn inner-monad (just v)))
+
+    (fapply [_ af av]
+      (p/mbind inner-monad
+               af
+               (fn [mf]
+                 (p/mbind maybe-monad
+                          mf
+                          (fn [f]
+                            (p/mbind inner-monad
+                                     av
+                                     (fn [mv]
+                                       (p/mbind maybe-monad
+                                                mv
+                                                (fn [v]
+                                                  (p/mreturn inner-monad (just (f v))))))))))))
+
     p/Monad
     (mreturn [m v]
       (p/mreturn inner-monad (just v)))

--- a/test/cats/monad/maybe_spec.cljc
+++ b/test/cats/monad/maybe_spec.cljc
@@ -72,6 +72,18 @@
              (m/with-monad maybe-vector-transformer
                (m/return 2))))
 
+    (t/is (= [(maybe/just 42)]
+             (m/with-monad maybe-vector-transformer
+               (m/fapply [(maybe/just inc)] [(maybe/just 41)]))))
+
+    (t/is (= [(maybe/just 42)
+              (maybe/just 99)
+              (maybe/just "41")
+              (maybe/just "98")]
+             (m/with-monad maybe-vector-transformer
+               (m/fapply [(maybe/just inc) (maybe/just str)]
+                         [(maybe/just 41) (maybe/just 98)]))))
+
     (t/is (= [(maybe/just 1)
               (maybe/just 2)
               (maybe/just 2)


### PR DESCRIPTION
This PR aims to implement applicative and functor instances for every monad transformer for being able to use combined applicatives in `alet`. Note that `alet` already uses `cats.core/join` in non-trivial cases so the applicatives used must conform to the monad instance most of the time.