### PR TITLE
Improvements to the context management

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,5 +1,5 @@
 (ns user
-  (:require [clojure.tools.namespace.repl :as repl]
+  (:require [clojure.tools.namespace.repl :as r]
             [clojure.walk :refer [macroexpand-all]]
             [clojure.pprint :refer [pprint]]
             [clojure.test :as test]))
@@ -27,8 +27,8 @@
   [& nss]
   (if (pos? (count nss))
     (binding [*namespaces* nss]
-      (repl/refresh :after 'user/run-tests'))
-    (repl/refresh :after 'user/run-tests')))
+      (r/refresh :after 'user/run-tests'))
+    (r/refresh :after 'user/run-tests')))
 
 (defn trace
   "Asynchronous friendly println variant."

--- a/src/cats/applicative/validation.cljc
+++ b/src/cats/applicative/validation.cljc
@@ -154,7 +154,7 @@
     p/Functor
     (fmap [_ f s]
       (if (ok? s)
-        (ok (f (.-v s)))
+        (ok (f (p/extract s)))
         s))
 
     p/Foldable

--- a/src/cats/applicative/validation.cljc
+++ b/src/cats/applicative/validation.cljc
@@ -37,10 +37,10 @@
 
 (deftype Ok [v]
   p/Context
-  (get-context [_] context)
+  (-get-context [_] context)
 
   p/Extract
-  (extract [_] v)
+  (-extract [_] v)
 
   #?(:clj clojure.lang.IDeref
      :cljs IDeref)
@@ -65,10 +65,10 @@
 
 (deftype Fail [v]
   p/Context
-  (get-context [_] context)
+  (-get-context [_] context)
 
   p/Extract
-  (extract [_] v)
+  (-extract [_] v)
 
   #?(:clj clojure.lang.IDeref
      :cljs IDeref)
@@ -123,7 +123,7 @@
   of the Validation applicative."
   [v]
   (if (satisfies? p/Context v)
-    (identical? (p/get-context v) context)
+    (identical? (p/-get-context v) context)
     false))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -137,50 +137,50 @@
     (-get-level [_] 10)
 
     p/Semigroup
-    (mappend [_ sv sv']
+    (-mappend [_ sv sv']
       (cond
         (and (fail? sv) (fail? sv'))
-        (fail (let [sv (p/extract sv)
-                    sv' (p/extract sv')]
-                (p/mappend (p/get-context sv) sv sv')))
+        (fail (let [sv (p/-extract sv)
+                    sv' (p/-extract sv')]
+                (p/-mappend (p/-get-context sv) sv sv')))
 
         (ok? sv) sv
         :else sv'))
 
     p/Monoid
-    (mempty [_]
+    (-mempty [_]
       (fail))
 
     p/Functor
-    (fmap [_ f s]
+    (-fmap [_ f s]
       (if (ok? s)
-        (ok (f (p/extract s)))
+        (ok (f (p/-extract s)))
         s))
 
     p/Foldable
-    (foldl [_ f z mv]
+    (-foldl [_ f z mv]
       (if (ok? mv)
-        (f z (p/extract mv))
+        (f z (p/-extract mv))
         z))
 
-    (foldr [_ f z mv]
+    (-foldr [_ f z mv]
       (if (ok? mv)
-        (f (p/extract mv) z)
+        (f (p/-extract mv) z)
         z))
 
     p/Applicative
-    (pure [_ v]
+    (-pure [_ v]
       (ok v))
 
-    (fapply [_ af av]
+    (-fapply [_ af av]
       (cond
         (and (ok? af) (ok? av))
-        (ok ((p/extract af) (p/extract av)))
+        (ok ((p/-extract af) (p/-extract av)))
 
         (and (fail? af) (fail? av))
-        (fail (let [af (p/extract af)
-                    av (p/extract av)]
-                (p/mappend (p/get-context af) af av)))
+        (fail (let [af (p/-extract af)
+                    av (p/-extract av)]
+                (p/-mappend (p/-get-context af) af av)))
 
         (ok? af) av
         :else af))))

--- a/src/cats/applicative/validation.cljc
+++ b/src/cats/applicative/validation.cljc
@@ -27,6 +27,7 @@
   "The Validation applicative implementation and helper functions
   for validating values. Isomorphic to Either."
   (:require [cats.protocols :as p]
+            [cats.context :as ctx]
             [cats.monad.either :as either]))
 
 (declare context)
@@ -134,7 +135,7 @@
   context
   (reify
     p/ContextClass
-    (-get-level [_] 10)
+    (-get-level [_] ctx/+level-default+)
 
     p/Semigroup
     (-mappend [_ sv sv']

--- a/src/cats/applicative/validation.cljc
+++ b/src/cats/applicative/validation.cljc
@@ -29,7 +29,7 @@
   (:require [cats.protocols :as p]
             [cats.monad.either :as either]))
 
-(declare validation-applicative)
+(declare context)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Type constructor and functions
@@ -37,7 +37,7 @@
 
 (deftype Ok [v]
   p/Context
-  (get-context [_] validation-applicative)
+  (get-context [_] context)
 
   p/Extract
   (extract [_] v)
@@ -65,7 +65,7 @@
 
 (deftype Fail [v]
   p/Context
-  (get-context [_] validation-applicative)
+  (get-context [_] context)
 
   p/Extract
   (extract [_] v)
@@ -123,7 +123,7 @@
   of the Validation applicative."
   [v]
   (if (satisfies? p/Context v)
-    (identical? (p/get-context v) validation-applicative)
+    (identical? (p/get-context v) context)
     false))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -131,8 +131,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def ^{:no-doc true}
-  validation-applicative
+  context
   (reify
+    p/ContextClass
+    (-get-level [_] 10)
+
     p/Semigroup
     (mappend [_ sv sv']
       (cond

--- a/src/cats/applicative/validation.cljc
+++ b/src/cats/applicative/validation.cljc
@@ -43,9 +43,10 @@
   p/Extract
   (-extract [_] v)
 
-  #?(:clj clojure.lang.IDeref
-     :cljs IDeref)
-  (#?(:clj deref :cljs -deref) [_] v)
+  #?@(:cljs [cljs.core/IDeref
+             (-deref [_] v)]
+      :clj  [clojure.lang.IDeref
+             (deref [_] v)])
 
   #?@(:clj
       [Object

--- a/src/cats/builtin.cljc
+++ b/src/cats/builtin.cljc
@@ -35,7 +35,7 @@
 
 (extend-type nil
   p/Context
-  (get-context [_] maybe/maybe-monad)
+  (get-context [_] maybe/context)
 
   p/Extract
   (extract [_] nil))
@@ -44,8 +44,11 @@
 ;; (Lazy) Sequence Monad
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def sequence-monad
+(def sequence-context
   (reify
+    p/ContextClass
+    (-get-level [_] 10)
+
     p/Semigroup
     (mappend [_ sv sv']
       (concat sv sv'))
@@ -102,14 +105,17 @@
 (extend-type #?(:clj  clojure.lang.LazySeq
                 :cljs cljs.core.LazySeq)
   p/Context
-  (get-context [_] sequence-monad))
+  (get-context [_] sequence-context))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Vector Monad
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def vector-monad
+(def vector-context
   (reify
+    p/ContextClass
+    (-get-level [_] 10)
+
     p/Semigroup
     (mappend [_ sv sv']
       (into sv sv'))
@@ -164,14 +170,17 @@
 (extend-type #?(:clj clojure.lang.PersistentVector
                 :cljs cljs.core.PersistentVector)
   p/Context
-  (get-context [_] vector-monad))
+  (get-context [_] vector-context))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Set Monad
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def set-monad
+(def set-context
   (reify
+    p/ContextClass
+    (-get-level [_] 10)
+
     p/Semigroup
     (mappend [_ sv sv']
       (s/union sv (set sv')))
@@ -211,14 +220,17 @@
 (extend-type #?(:clj clojure.lang.PersistentHashSet
                 :cljs cljs.core.PersistentHashSet)
   p/Context
-  (get-context [_] set-monad))
+  (get-context [_] set-context))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Map Monoid
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def map-monoid
+(def map-context
   (reify
+    p/ContextClass
+    (-get-level [_] 10)
+
     p/Semigroup
     (mappend [_ sv sv']
       (merge sv sv'))
@@ -230,14 +242,14 @@
 (extend-type #?(:clj clojure.lang.PersistentHashMap
                 :cljs cljs.core.PersistentHashMap)
   p/Context
-  (get-context [_] map-monoid))
+  (get-context [_] map-context))
 
 #?(:clj
    (extend-type clojure.lang.PersistentArrayMap
      p/Context
-     (get-context [_] map-monoid)))
+     (get-context [_] map-context)))
 
 #?(:clj
    (extend-type clojure.lang.PersistentTreeMap
      p/Context
-     (get-context [_] map-monoid)))
+     (get-context [_] map-context)))

--- a/src/cats/builtin.cljc
+++ b/src/cats/builtin.cljc
@@ -35,10 +35,10 @@
 
 (extend-type nil
   p/Context
-  (get-context [_] maybe/context)
+  (-get-context [_] maybe/context)
 
   p/Extract
-  (extract [_] nil))
+  (-extract [_] nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; (Lazy) Sequence Monad
@@ -50,62 +50,62 @@
     (-get-level [_] 10)
 
     p/Semigroup
-    (mappend [_ sv sv']
+    (-mappend [_ sv sv']
       (concat sv sv'))
 
     p/Monoid
-    (mempty [_]
+    (-mempty [_]
       (lazy-seq []))
 
     p/Functor
-    (fmap [_ f v]
+    (-fmap [_ f v]
       (map f v))
 
     p/Applicative
-    (pure [_ v]
+    (-pure [_ v]
       (lazy-seq [v]))
 
-    (fapply [_ self av]
+    (-fapply [_ self av]
       (for [f self
             v av]
            (f v)))
 
     p/Monad
-    (mreturn [_ v]
+    (-mreturn [_ v]
       (lazy-seq [v]))
 
-    (mbind [_ self f]
+    (-mbind [_ self f]
       (apply concat (map f self)))
 
     p/MonadZero
-    (mzero [_]
+    (-mzero [_]
       (lazy-seq []))
 
     p/MonadPlus
-    (mplus [_ mv mv']
+    (-mplus [_ mv mv']
       (concat mv mv'))
 
     p/Foldable
-    (foldr [ctx f z xs]
+    (-foldr [ctx f z xs]
       (lazy-seq
        (let [x (first xs)
              xs (rest xs)]
          (if (nil? x)
            z
-           (f x (p/foldr ctx f z xs))))))
+           (f x (p/-foldr ctx f z xs))))))
 
-    (foldl [ctx f z xs]
+    (-foldl [ctx f z xs]
       (lazy-seq
        (let [x (first xs)
              xs (rest xs)]
          (if (nil? x)
            z
-           (p/foldl ctx f (f z x) xs)))))))
+           (p/-foldl ctx f (f z x) xs)))))))
 
 (extend-type #?(:clj  clojure.lang.LazySeq
                 :cljs cljs.core.LazySeq)
   p/Context
-  (get-context [_] sequence-context))
+  (-get-context [_] sequence-context))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Vector Monad
@@ -117,60 +117,60 @@
     (-get-level [_] 10)
 
     p/Semigroup
-    (mappend [_ sv sv']
+    (-mappend [_ sv sv']
       (into sv sv'))
 
     p/Monoid
-    (mempty [_]
+    (-mempty [_]
       [])
 
     p/Functor
-    (fmap [_ f v]
+    (-fmap [_ f v]
       (vec (map f v)))
 
     p/Applicative
-    (pure [_ v]
+    (-pure [_ v]
       [v])
 
-    (fapply [_ self av]
+    (-fapply [_ self av]
       (vec (for [f self
                  v av]
              (f v))))
 
     p/Monad
-    (mreturn [_ v]
+    (-mreturn [_ v]
       [v])
 
-    (mbind [_ self f]
+    (-mbind [_ self f]
       (vec (mapcat f self)))
 
     p/MonadZero
-    (mzero [_]
+    (-mzero [_]
       [])
 
     p/MonadPlus
-    (mplus [_ mv mv']
+    (-mplus [_ mv mv']
       (into mv mv'))
 
     p/Foldable
-    (foldr [ctx f z xs]
+    (-foldr [ctx f z xs]
       (let [x (first xs)
             xs (rest xs)]
         (if (nil? x)
           z
-          (f x (p/foldr ctx f z xs)))))
+          (f x (p/-foldr ctx f z xs)))))
 
-    (foldl [ctx f z xs]
+    (-foldl [ctx f z xs]
       (let [x (first xs)
             xs (rest xs)]
         (if (nil? x)
           z
-          (p/foldl ctx f (f z x) xs))))))
+          (p/-foldl ctx f (f z x) xs))))))
 
 (extend-type #?(:clj clojure.lang.PersistentVector
                 :cljs cljs.core.PersistentVector)
   p/Context
-  (get-context [_] vector-context))
+  (-get-context [_] vector-context))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Set Monad
@@ -182,45 +182,45 @@
     (-get-level [_] 10)
 
     p/Semigroup
-    (mappend [_ sv sv']
+    (-mappend [_ sv sv']
       (s/union sv (set sv')))
 
     p/Monoid
-    (mempty [_]
+    (-mempty [_]
       #{})
 
     p/Functor
-    (fmap [_ f self]
+    (-fmap [_ f self]
       (set (map f self)))
 
     p/Applicative
-    (pure [_ v]
+    (-pure [_ v]
       #{v})
 
-    (fapply [_ self av]
+    (-fapply [_ self av]
       (set (for [f self
                  v av]
              (f v))))
 
     p/Monad
-    (mreturn [_ v]
+    (-mreturn [_ v]
       #{v})
 
-    (mbind [_ self f]
+    (-mbind [_ self f]
       (apply s/union (map f self)))
 
     p/MonadZero
-    (mzero [_]
+    (-mzero [_]
       #{})
 
     p/MonadPlus
-    (mplus [_ mv mv']
+    (-mplus [_ mv mv']
       (s/union mv mv'))))
 
 (extend-type #?(:clj clojure.lang.PersistentHashSet
                 :cljs cljs.core.PersistentHashSet)
   p/Context
-  (get-context [_] set-context))
+  (-get-context [_] set-context))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Map Monoid
@@ -232,24 +232,32 @@
     (-get-level [_] 10)
 
     p/Semigroup
-    (mappend [_ sv sv']
+    (-mappend [_ sv sv']
       (merge sv sv'))
 
     p/Monoid
-    (mempty [_]
+    (-mempty [_]
       {})))
 
 (extend-type #?(:clj clojure.lang.PersistentHashMap
                 :cljs cljs.core.PersistentHashMap)
   p/Context
-  (get-context [_] map-context))
+  (-get-context [_] map-context))
 
 #?(:clj
    (extend-type clojure.lang.PersistentArrayMap
      p/Context
-     (get-context [_] map-context)))
+     (-get-context [_] map-context))
+   :cljs
+   (extend-type cljs.core.PersistentArrayMap
+     p/Context
+     (-get-context [_] map-context)))
 
 #?(:clj
    (extend-type clojure.lang.PersistentTreeMap
      p/Context
-     (get-context [_] map-context)))
+     (-get-context [_] map-context))
+   :cljs
+   (extend-type cljs.core.PersistentTreeMap
+     p/Context
+     (-get-context [_] map-context)))

--- a/src/cats/builtin.cljc
+++ b/src/cats/builtin.cljc
@@ -27,6 +27,7 @@
   "Clojure(Script) built-in types extensions."
   (:require [clojure.set :as s]
             [cats.monad.maybe :as maybe]
+            [cats.context :as ctx]
             [cats.protocols :as p]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -47,7 +48,7 @@
 (def sequence-context
   (reify
     p/ContextClass
-    (-get-level [_] 10)
+    (-get-level [_] ctx/+level-default+)
 
     p/Semigroup
     (-mappend [_ sv sv']
@@ -114,7 +115,7 @@
 (def vector-context
   (reify
     p/ContextClass
-    (-get-level [_] 10)
+    (-get-level [_] ctx/+level-default+)
 
     p/Semigroup
     (-mappend [_ sv sv']
@@ -179,7 +180,7 @@
 (def set-context
   (reify
     p/ContextClass
-    (-get-level [_] 10)
+    (-get-level [_] ctx/+level-default+)
 
     p/Semigroup
     (-mappend [_ sv sv']
@@ -229,7 +230,7 @@
 (def map-context
   (reify
     p/ContextClass
-    (-get-level [_] 10)
+    (-get-level [_] ctx/+level-default+)
 
     p/Semigroup
     (-mappend [_ sv sv']

--- a/src/cats/builtin.cljc
+++ b/src/cats/builtin.cljc
@@ -236,3 +236,8 @@
    (extend-type clojure.lang.PersistentArrayMap
      p/Context
      (get-context [_] map-monoid)))
+
+#?(:clj
+   (extend-type clojure.lang.PersistentTreeMap
+     p/Context
+     (get-context [_] map-monoid)))

--- a/src/cats/context.cljc
+++ b/src/cats/context.cljc
@@ -30,21 +30,28 @@
 (def ^{:dynamic true :no-doc true}
   *context* nil)
 
+(defn throw-ilegal-argument
+  {:no-doc true :internal true}
+  [text]
+  #?(:cljs (throw (ex-info text {}))
+     :clj  (throw (IllegalArgumentException. text))))
+
 #?(:clj
    (defmacro with-context
      "Set current context to specific monad."
      [ctx & body]
-     `(cond
-        (satisfies? p/MonadTrans ~ctx)
-        (binding [*context* ~ctx]
-          ~@body)
-
-        (satisfies? p/MonadTrans *context*)
-        (do ~@body)
-
-        :else
-        (binding [*context* ~ctx]
-          ~@body))))
+     `(do
+        (when (not (satisfies? p/ContextClass ~ctx))
+          (throw-ilegal-argument "The provided context does not implements ContextClass."))
+        (if (nil? *context*)
+          (binding [*context* ~ctx]
+            ~@body)
+          (let [clevel# (p/-get-level *context*)
+                nlevel# (p/-get-level ~ctx)]
+            (if (> nlevel# clevel#)
+              (binding [*context* ~ctx]
+                ~@body)
+              (do ~@body)))))))
 
 #?(:clj
    (defmacro with-monad
@@ -53,23 +60,28 @@
      `(with-context ~ctx
         ~@body)))
 
+(def ^:private not-nil? (comp not nil?))
+
 (defn get-current
   "Get current context or obtain it from
   the provided instance."
   {:no-doc true}
-  ([] (get-current nil))
-  ([default]
+  ([]
+   (if (not-nil? *context*)
+     *context*
+     (throw-ilegal-argument
+      "No context is set and it can not be automatically resolved.")))
+  ([param]
    (cond
-     (not (nil? *context*))
+     (not-nil? *context*)
      *context*
 
-     (satisfies? p/Context default)
-     (p/get-context default)
+     (satisfies? p/Context param)
+     (p/get-context param)
 
-     (satisfies? p/Monad default)
-     default
+     (satisfies? p/ContextClass param)
+     param
 
      :else
-     (throw (#?(:clj IllegalArgumentException.
-                :cljs js/Error.)
-             "You are using return/pure/mzero function without context.")))))
+     (throw-ilegal-argument
+      "No context is set and it can not be automatically resolved."))))

--- a/src/cats/context.cljc
+++ b/src/cats/context.cljc
@@ -77,7 +77,7 @@
      *context*
 
      (satisfies? p/Context param)
-     (p/get-context param)
+     (p/-get-context param)
 
      (satisfies? p/ContextClass param)
      param

--- a/src/cats/context.cljc
+++ b/src/cats/context.cljc
@@ -24,11 +24,12 @@
 ;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 (ns cats.context
-  "A context management macros."
+  "A cats context management."
   (:require [cats.protocols :as p]))
 
-(def ^{:dynamic true :no-doc true}
-  *context* nil)
+(def ^:dynamic *context* nil)
+(def ^:const +level-default+ 10)
+(def ^:const +level-transformer+ 100)
 
 (defn throw-ilegal-argument
   {:no-doc true :internal true}

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -67,8 +67,6 @@
    (let [ctx (ctx/get-current ctx-or-val)]
      (p/-mempty ctx))))
 
-
-;; TODO: improve performance
 (defn mappend
   [& svs]
   {:pre [(seq svs)]}
@@ -123,8 +121,6 @@
    (p/-mzero (ctx/get-current)))
   ([ctx]
    (p/-mzero ctx)))
-
-;; TODO: improve performance
 
 (defn mplus
   [& mvs]

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -632,10 +632,9 @@
       ;=> <Nothing>
   "
   [p mv]
-  (ctx/with-context (ctx/get-current mv)
-    (mlet [v mv
-           :when (p v)]
-      (return v))))
+  (mlet [v mv
+         :when (p v)]
+    (return v)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Haskell-style aliases and util functions.

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -60,9 +60,12 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn mempty
-  []
-  (let [ctx (ctx/get-current)]
-    (p/mempty ctx)))
+  ([]
+   (let [ctx (ctx/get-current)]
+     (p/mempty ctx)))
+  ([context]
+   (let [ctx (ctx/get-current context)]
+     (p/mempty ctx))))
 
 (defn mappend
   [& svs]

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -62,10 +62,10 @@
 (defn mempty
   ([]
    (let [ctx (ctx/get-current)]
-     (p/mempty ctx)))
+     (p/-mempty ctx)))
   ([ctx-or-val]
    (let [ctx (ctx/get-current ctx-or-val)]
-     (p/mempty ctx))))
+     (p/-mempty ctx))))
 
 
 ;; TODO: improve performance
@@ -73,7 +73,7 @@
   [& svs]
   {:pre [(seq svs)]}
   (let [ctx (ctx/get-current (first svs))]
-    (reduce (partial p/mappend ctx) svs)))
+    (reduce (partial p/-mappend ctx) svs)))
 
 (defn pure
   "Given any value `v`, return it wrapped in
@@ -94,13 +94,13 @@
       ;; => #<Right [1]>
   "
   ([v] (pure (ctx/get-current) v))
-  ([ctx v] (p/pure ctx v)))
+  ([ctx v] (p/-pure ctx v)))
 
 (defn return
   "This is a monad version of `pure` and works
   identically to it."
   ([v] (return (ctx/get-current) v))
-  ([ctx v] (p/mreturn ctx v)))
+  ([ctx v] (p/-mreturn ctx v)))
 
 (defn bind
   "Given a monadic value `mv` and a function `f`,
@@ -116,13 +116,13 @@
   [mv f]
   (let [ctx (ctx/get-current mv)]
     (ctx/with-context ctx
-      (p/mbind ctx mv f))))
+      (p/-mbind ctx mv f))))
 
 (defn mzero
   ([]
-   (p/mzero (ctx/get-current)))
+   (p/-mzero (ctx/get-current)))
   ([ctx]
-   (p/mzero ctx)))
+   (p/-mzero ctx)))
 
 ;; TODO: improve performance
 
@@ -130,7 +130,7 @@
   [& mvs]
   {:pre [(seq mvs)]}
   (let [ctx (ctx/get-current (first mvs))]
-    (reduce (partial p/mplus ctx) mvs)))
+    (reduce (partial p/-mplus ctx) mvs)))
 
 (defn guard
   [b]
@@ -152,7 +152,7 @@
      (fmap f fv)))
   ([f fv]
    (-> (ctx/get-current fv)
-       (p/fmap f fv))))
+       (p/-fmap f fv))))
 
 (defn fapply
   "Given a function wrapped in a monadic context `af`,
@@ -165,7 +165,7 @@
   [af & avs]
   {:pre [(seq avs)]}
   (let [ctx (ctx/get-current af)]
-    (reduce (partial p/fapply ctx) af avs)))
+    (reduce (partial p/-fapply ctx) af avs)))
 
 
 ;; TODO: review it, seems wrong and should be a macro?
@@ -190,8 +190,8 @@
 (defn lift
   "Lift a value from the inner monad of a monad transformer
   into a value of the monad transformer."
-  ([mv] (p/lift ctx/*context* mv))
-  ([m mv] (p/lift m mv)))
+  ([mv] (p/-lift ctx/*context* mv))
+  ([m mv] (p/-lift m mv)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Monadic Let Macro
@@ -696,23 +696,23 @@
   "Generic function to unwrap/extract
   the inner value of a container."
   [v]
-  (p/extract v))
+  (p/-extract v))
 
 (def <> mappend)
 
 (defn foldr
   "Perform a right-associative fold on the data structure."
   [f z xs]
-  (let [ctx (p/get-context xs)]
+  (let [ctx (p/-get-context xs)]
     (ctx/with-context ctx
-      (p/foldr ctx f z xs))))
+      (p/-foldr ctx f z xs))))
 
 (defn foldl
   "Perform a left-associative fold on the data structure."
   [f z xs]
-  (let [ctx (p/get-context xs)]
+  (let [ctx (p/-get-context xs)]
     (ctx/with-context ctx
-      (p/foldl ctx f z xs))))
+      (p/-foldl ctx f z xs))))
 
 (defn foldm
   "Given an optional monadic context, a function that takes two non-monadic

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -504,8 +504,7 @@
               (throw (IllegalArgumentException. "The given function is either variadic or has multiple arities, provide an arity for currying.")))
             (throw (IllegalArgumentException. "The given function doesn't have arity metadata, provide an arity for currying."))))))
      ([n f]
-      {:pre [(or (< n 21)
-                 (throw (IllegalArgumentException. "Clojure doesn't allow more than 20 positional arguments")))]}
+      {:pre [(< n 21)]}
       (let [args (repeatedly n gensym)
             body `(~f ~@args)]
         `(curry* ~args ~body)))))

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -67,6 +67,8 @@
    (let [ctx (ctx/get-current ctx-or-val)]
      (p/mempty ctx))))
 
+
+;; TODO: improve performance
 (defn mappend
   [& svs]
   {:pre [(seq svs)]}
@@ -122,6 +124,8 @@
   ([ctx]
    (p/mzero ctx)))
 
+;; TODO: improve performance
+
 (defn mplus
   [& mvs]
   {:pre [(seq mvs)]}
@@ -163,6 +167,8 @@
   (let [ctx (ctx/get-current af)]
     (reduce (partial p/fapply ctx) af avs)))
 
+
+;; TODO: review it, seems wrong and should be a macro?
 (defn when
   "Given an expression and a monadic value,
   if the expression is logical true, return the monadic value.
@@ -172,6 +178,7 @@
   ([ctx b mv]
    (if b mv (return ctx nil))))
 
+;; TODO: review it, seems wrong and should be a macro?
 (defn unless
   "Given an expression and a monadic value,
   if the expression is not logical true, return the monadic value.

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -235,7 +235,8 @@
                       `(bind ~r (fn [~l] ~acc))))
                   `(do ~@body)))))
 
-(defn- deps [expr syms]
+(defn- deps
+  [expr syms]
   (cond
     (and (symbol? expr)
          (contains? syms expr))
@@ -247,10 +248,12 @@
     :else
     '()))
 
-(defn- rename-sym [expr renames]
+(defn- rename-sym
+  [expr renames]
   (get renames expr expr))
 
-(defn- rename [expr renames]
+(defn- rename
+  [expr renames]
   (cond
     (symbol? expr)
     (rename-sym expr renames)
@@ -431,9 +434,7 @@
         `(fmap (fn [~@(map first bindings)]
                  ~@body)
                ~@(map second bindings))
-        (alet* batches env body))))
-
-)
+        (alet* batches env body)))))
 
 (defn- arglists
   [var]

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -63,8 +63,8 @@
   ([]
    (let [ctx (ctx/get-current)]
      (p/mempty ctx)))
-  ([context]
-   (let [ctx (ctx/get-current context)]
+  ([ctx-or-val]
+   (let [ctx (ctx/get-current ctx-or-val)]
      (p/mempty ctx))))
 
 (defn mappend

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -84,11 +84,11 @@
 
   Example:
 
-      (with-context either/either-monad
+      (with-context either/context
         (pure 1))
       ;; => #<Right [1]>
 
-      (pure either/either-monad 1)
+      (pure either/context 1)
       ;; => #<Right [1]>
   "
   ([v] (pure (ctx/get-current) v))
@@ -723,17 +723,17 @@
           (maybe/just (/ x y))))
 
       (m/foldm m-div 1 [1 2 3])
-      (m/foldm maybe/maybe-monad m-div 1 [1 2 3])
+      (m/foldm maybe/context m-div 1 [1 2 3])
       ;; => #<Just 1/6>
 
-      (m/foldm maybe/maybe-monad m-div 1 [1 0 3])
+      (m/foldm maybe/context m-div 1 [1 0 3])
       ;; => #<Nothing>
 
       (foldm m-div 1 [])
       ;; => Exception
 
-      (m/foldm maybe/maybe-monad m-div 1 [])
-      (ctx/with-context maybe/maybe-monad
+      (m/foldm maybe/context m-div 1 [])
+      (ctx/with-context maybe/context
         (foldm m-div 1 []))
       ;; => #<Just 1>
   "

--- a/src/cats/labs/channel.cljc
+++ b/src/cats/labs/channel.cljc
@@ -72,7 +72,7 @@
   context
   (reify
     p/ContextClass
-    (-get-level [_] 10)
+    (-get-level [_] ctx/+level-default+)
 
     p/Functor
     (-fmap [_ f mv]

--- a/src/cats/labs/channel.cljc
+++ b/src/cats/labs/channel.cljc
@@ -75,45 +75,45 @@
     (-get-level [_] 10)
 
     p/Functor
-    (fmap [_ f mv]
+    (-fmap [_ f mv]
       (let [c (a/chan 1 (map f))]
         (a/pipe mv c)
         c))
 
     p/Semigroup
-    (mappend [_ sv sv']
+    (-mappend [_ sv sv']
       (chain-chans sv sv'))
 
     p/Monoid
-    (mempty [_]
+    (-mempty [_]
       (let [c (a/chan)]
         (a/close! c)
         c))
 
     p/Applicative
-    (pure [_ v]
+    (-pure [_ v]
       (let [c (a/chan 1)]
         (a/put! c v)
         (a/close! c)
         c))
 
-    (fapply [mn af av]
+    (-fapply [mn af av]
       (let [c (a/chan 1)]
         (go
           (let [af' (a/<! (a/reduce conj [] af))
                 av' (a/<! (a/reduce conj [] av))
-                ctx (p/get-context [])]
-            (a/onto-chan c (p/fapply ctx af' av'))))
+                ctx (p/-get-context [])]
+            (a/onto-chan c (p/-fapply ctx af' av'))))
         c))
 
     p/Monad
-    (mreturn [_ v]
+    (-mreturn [_ v]
       (let [c (a/chan 1)]
         (a/put! c v)
         (a/close! c)
         c))
 
-    (mbind [it mv f]
+    (-mbind [it mv f]
       (let [ctx ctx/*context*
             c (a/chan 1)]
         (go-loop []
@@ -138,5 +138,5 @@
 (extend-type #?(:clj  clojure.core.async.impl.channels.ManyToManyChannel
                 :cljs cljs.core.async.impl.channels.ManyToManyChannel)
   p/Context
-  (get-context [_] context))
+  (-get-context [_] context))
 

--- a/src/cats/labs/channel.cljc
+++ b/src/cats/labs/channel.cljc
@@ -69,8 +69,11 @@
     out))
 
 (def ^{:no-doc true}
-  channel-monad
+  context
   (reify
+    p/ContextClass
+    (-get-level [_] 10)
+
     p/Functor
     (fmap [_ f mv]
       (let [c (a/chan 1 (map f))]
@@ -135,5 +138,5 @@
 (extend-type #?(:clj  clojure.core.async.impl.channels.ManyToManyChannel
                 :cljs cljs.core.async.impl.channels.ManyToManyChannel)
   p/Context
-  (get-context [_] channel-monad))
+  (get-context [_] context))
 

--- a/src/cats/labs/continuation.cljc
+++ b/src/cats/labs/continuation.cljc
@@ -59,7 +59,7 @@
 (def context
   (reify
     p/ContextClass
-    (-get-level [_] 10)
+    (-get-level [_] ctx/+level-default+)
 
     p/Monad
     (-mreturn [_ v]

--- a/src/cats/labs/continuation.cljc
+++ b/src/cats/labs/continuation.cljc
@@ -38,7 +38,7 @@
 
 (deftype Continuation [mfn]
   p/Context
-  (get-context [_] context)
+  (-get-context [_] context)
 
   #?(:clj  clojure.lang.IFn
      :cljs cljs.core/IFn)
@@ -62,10 +62,10 @@
     (-get-level [_] 10)
 
     p/Monad
-    (mreturn [_ v]
+    (-mreturn [_ v]
       (Continuation. (fn [c] (c v))))
 
-    (mbind [_ self mf]
+    (-mbind [_ self mf]
       (Continuation. (fn [c]
                        (self (fn [v]
                                ((mf v) c))))))))

--- a/src/cats/labs/continuation.cljc
+++ b/src/cats/labs/continuation.cljc
@@ -30,7 +30,7 @@
      :cljs (:require [cats.protocols :as p]
                      [cats.context :as ctx :include-macros true])))
 
-(declare continuation-monad)
+(declare context)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Type constructors and functions
@@ -38,7 +38,7 @@
 
 (deftype Continuation [mfn]
   p/Context
-  (get-context [_] continuation-monad)
+  (get-context [_] context)
 
   #?(:clj  clojure.lang.IFn
      :cljs cljs.core/IFn)
@@ -56,8 +56,11 @@
 ;; Monad definition
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def continuation-monad
+(def context
   (reify
+    p/ContextClass
+    (-get-level [_] 10)
+
     p/Monad
     (mreturn [_ v]
       (Continuation. (fn [c] (c v))))
@@ -75,7 +78,7 @@
   "Given a Continuation instance, execute the
   wrapped computation and return its value."
   [cont]
-  (ctx/with-monad continuation-monad
+  (ctx/with-monad context
     (cont identity)))
 
 (defn call-cc

--- a/src/cats/labs/reader.cljc
+++ b/src/cats/labs/reader.cljc
@@ -50,10 +50,12 @@
   p/Context
   (-get-context [_] context)
 
-  #?(:clj  clojure.lang.IFn
-     :cljs cljs.core/IFn)
-  (#?(:clj invoke :cljs -invoke) [self seed]
-    (mfn seed)))
+  #?@(:cljs [cljs.core/IFn
+             (-invoke [self seed]
+               (mfn seed))]
+      :clj  [clojure.lang.IFn
+             (invoke [self seed]
+               (mfn seed))]))
 
 (alter-meta! #'->Reader assoc :private true)
 
@@ -158,13 +160,11 @@
 ;; Reader monad functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; TODO: the usage of get-current seems to be redundant
-
 (defn run-reader
   "Given a Reader instance, execute the
   wrapped computation and returns a value."
   [reader seed]
-  (ctx/with-monad (ctx/get-current context)
+  (ctx/with-context context
     (reader seed)))
 
 (def ask

--- a/src/cats/labs/reader.cljc
+++ b/src/cats/labs/reader.cljc
@@ -84,7 +84,7 @@
   context
   (reify
     p/ContextClass
-    (-get-level [_] 10)
+    (-get-level [_] ctx/+level-default+)
 
     p/Functor
     (-fmap [_ f fv]
@@ -118,7 +118,7 @@
   [inner-monad]
   (reify
     p/ContextClass
-    (-get-level [_] 100)
+    (-get-level [_] ctx/+level-transformer+)
 
     p/Functor
     (-fmap [_ f fv]

--- a/src/cats/labs/reader.cljc
+++ b/src/cats/labs/reader.cljc
@@ -48,7 +48,7 @@
 
 (deftype Reader [mfn]
   p/Context
-  (get-context [_] context)
+  (-get-context [_] context)
 
   #?(:clj  clojure.lang.IFn
      :cljs cljs.core/IFn)
@@ -85,16 +85,16 @@
     (-get-level [_] 10)
 
     p/Functor
-    (fmap [_ f fv]
+    (-fmap [_ f fv]
       (reader (fn [env]
                 (f (fv env)))))
 
     p/Monad
-    (mreturn [_ v]
+    (-mreturn [_ v]
       (reader (fn [env]
                 v)))
 
-    (mbind [_ mv f]
+    (-mbind [_ mv f]
       (reader (fn [env]
                 ((f (mv env)) env))))
 
@@ -119,36 +119,36 @@
     (-get-level [_] 100)
 
     p/Functor
-    (fmap [_ f fv]
+    (-fmap [_ f fv]
       (reader (fn [env]
-                (p/fmap inner-monad f (fv env)))))
+                (p/-fmap inner-monad f (fv env)))))
 
     p/Monad
-    (mreturn [_ v]
-      (p/mreturn context (p/mreturn inner-monad v)))
+    (-mreturn [_ v]
+      (p/-mreturn context (p/-mreturn inner-monad v)))
 
-    (mbind [_ mr f]
+    (-mbind [_ mr f]
       (fn [env]
-        (p/mbind inner-monad
+        (p/-mbind inner-monad
                      (mr env)
                      (fn [a]
                        ((f a) env)))))
 
     p/MonadTrans
-    (base [_]
+    (-base [_]
       context)
 
-    (inner [_]
+    (-inner [_]
       inner-monad)
 
-    (lift [m mv]
+    (-lift [m mv]
       (fn [_]
         mv))
 
     MonadReader
     (-ask [_]
       (fn [env]
-        (p/mreturn inner-monad env)))
+        (p/-mreturn inner-monad env)))
 
     (-local [_ f mr]
       (fn [env]

--- a/src/cats/labs/state.cljc
+++ b/src/cats/labs/state.cljc
@@ -51,7 +51,7 @@
 
 (deftype State [mfn]
   p/Context
-  (get-context [_] context)
+  (-get-context [_] context)
 
   #?(:clj  clojure.lang.IFn
      :cljs cljs.core/IFn)
@@ -88,16 +88,16 @@
     (-get-level [_] 10)
 
     p/Functor
-    (fmap [_ f fv]
+    (-fmap [_ f fv]
       (state-t (fn [s]
                  (let [[v ns]  (fv s)]
                    (d/pair (f v) ns)))))
 
     p/Monad
-    (mreturn [_ v]
+    (-mreturn [_ v]
       (state-t (partial d/pair v)))
 
-    (mbind [_ self f]
+    (-mbind [_ self f]
       (state-t (fn [s]
                  (let [p        (self s)
                        value    (.-fst p)
@@ -126,70 +126,70 @@
     (-get-level [_] 100)
 
     p/Functor
-    (fmap [_ f fv]
+    (-fmap [_ f fv]
       (state-t (fn [s]
                  (let [wr (fv s)]
-                   (p/fmap inner-monad
-                           (fn [[v ns]]
-                             (d/pair (f v) ns))
-                           wr)))))
+                   (p/-fmap inner-monad
+                            (fn [[v ns]]
+                              (d/pair (f v) ns))
+                            wr)))))
 
     p/Monad
-    (mreturn [_ v]
+    (-mreturn [_ v]
       (state-t (fn [s]
-                 (p/mreturn inner-monad
-                            (d/pair v s)))))
+                 (p/-mreturn inner-monad
+                             (d/pair v s)))))
 
-    (mbind [_ self f]
+    (-mbind [_ self f]
       (state-t (fn [s]
                  (let [mp (self s)]
-                   (p/mbind inner-monad
-                            mp
-                            (fn [[v ns]]
-                              ((f v) ns)))))))
+                   (p/-mbind inner-monad
+                             mp
+                             (fn [[v ns]]
+                               ((f v) ns)))))))
 
-    ; FIXME: Conditionally if `inner-monad` is MonadZero
+                                        ; FIXME: Conditionally if `inner-monad` is MonadZero
     p/MonadZero
-    (mzero [_]
+    (-mzero [_]
       (state-t (fn [s]
-                 (p/mzero inner-monad))))
+                 (p/-mzero inner-monad))))
 
-    ; FIXME: Conditionally if `inner-monad` is MonadPlus
+                                        ; FIXME: Conditionally if `inner-monad` is MonadPlus
     p/MonadPlus
-    (mplus [_ mv mv']
+    (-mplus [_ mv mv']
       (state-t (fn [s]
-                 (p/mplus inner-monad (mv s) (mv' s)))))
+                 (p/-mplus inner-monad (mv s) (mv' s)))))
 
     MonadState
     (-get-state [_]
       (state-t (fn [s]
-                 (p/mreturn inner-monad
-                            (d/pair s s)))))
+                 (p/-mreturn inner-monad
+                             (d/pair s s)))))
 
     (-put-state [_ newstate]
       (state-t (fn [s]
-                 (p/mreturn inner-monad
-                            (d/pair s newstate)))))
+                 (p/-mreturn inner-monad
+                             (d/pair s newstate)))))
 
     (-swap-state [_ f]
       (state-t (fn [s]
-                 (p/mreturn inner-monad
-                            (d/pair s (f s))))))
+                 (p/-mreturn inner-monad
+                             (d/pair s (f s))))))
 
     p/MonadTrans
-    (base [_]
+    (-base [_]
       context)
 
-    (inner [_]
+    (-inner [_]
       inner-monad)
 
-    (lift [_ mv]
+    (-lift [_ mv]
       (state-t (fn [s]
-                 (p/mbind inner-monad
-                          mv
-                          (fn [v]
-                            (p/mreturn inner-monad
-                                       (d/pair v s)))))))))
+                 (p/-mbind inner-monad
+                           mv
+                           (fn [v]
+                             (p/-mreturn inner-monad
+                                         (d/pair v s)))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Public Api

--- a/src/cats/labs/state.cljc
+++ b/src/cats/labs/state.cljc
@@ -53,10 +53,12 @@
   p/Context
   (-get-context [_] context)
 
-  #?(:clj  clojure.lang.IFn
-     :cljs cljs.core/IFn)
-  (#?(:clj invoke :cljs -invoke) [self seed]
-    (mfn seed)))
+  #?@(:cljs [cljs.core/IFn
+             (-invoke [self seed]
+               (mfn seed))]
+      :clj  [clojure.lang.IFn
+             (invoke [self seed]
+               (mfn seed))]))
 
 (alter-meta! #'->State assoc :private true)
 
@@ -213,8 +215,6 @@
   [f]
   (-swap-state (ctx/get-current context) f))
 
-;; TODO: seems that ctx/get-current is redundant
-
 (defn run-state
   "Given a State instance, execute the
   wrapped computation and returns a cats.data.Pair
@@ -229,7 +229,7 @@
 
   This should be return something to: #<Pair [1 2]>"
   [state seed]
-  (ctx/with-monad (ctx/get-current context)
+  (ctx/with-context context
     (state seed)))
 
 (defn eval-state

--- a/src/cats/labs/state.cljc
+++ b/src/cats/labs/state.cljc
@@ -87,7 +87,7 @@
   context
   (reify
     p/ContextClass
-    (-get-level [_] 10)
+    (-get-level [_] ctx/+level-default+)
 
     p/Functor
     (-fmap [_ f fv]
@@ -125,7 +125,7 @@
   [inner-monad]
   (reify
     p/ContextClass
-    (-get-level [_] 100)
+    (-get-level [_] ctx/+level-transformer+)
 
     p/Functor
     (-fmap [_ f fv]

--- a/src/cats/labs/writer.cljc
+++ b/src/cats/labs/writer.cljc
@@ -95,7 +95,7 @@
   context
   (reify
     p/ContextClass
-    (-get-level [_] 10)
+    (-get-level [_] ctx/+level-default+)
 
     p/Monad
     (-mreturn [_ v]
@@ -126,7 +126,7 @@
   [inner-context]
   (reify
     p/ContextClass
-    (-get-level [_] 100)
+    (-get-level [_] ctx/+level-transformer+)
 
     p/Monad
     (-mreturn [_ v]

--- a/src/cats/labs/writer.cljc
+++ b/src/cats/labs/writer.cljc
@@ -61,11 +61,12 @@
   p/Context
   (-get-context [_] context)
 
-  #?(:clj  clojure.lang.IFn
-     :cljs cljs.core/IFn)
-
-  (#?(:clj invoke :cljs -invoke) [self seed]
-    (mfn seed)))
+  #?@(:cljs [cljs.core/IFn
+             (-invoke [self seed]
+               (mfn seed))]
+      :clj  [clojure.lang.IFn
+             (invoke [self seed]
+               (mfn seed))]))
 
 (alter-meta! #'->Writer assoc :private true)
 
@@ -130,7 +131,7 @@
     p/Monad
     (-mreturn [_ v]
       (p/-mreturn inner-context
-                 (d/pair v (p/-mempty b/vector-context))))
+                  (d/pair v (p/-mempty b/vector-context))))
 
     (-mbind [_ mv f]
       (p/-mbind inner-context
@@ -179,8 +180,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Writer monad functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; TODO: seems that with-context is missing here
 
 (defn tell
   "Add the value to the log."

--- a/src/cats/labs/writer.cljc
+++ b/src/cats/labs/writer.cljc
@@ -59,7 +59,7 @@
 
 (deftype Writer [mfn]
   p/Context
-  (get-context [_] context)
+  (-get-context [_] context)
 
   #?(:clj  clojure.lang.IFn
      :cljs cljs.core/IFn)
@@ -97,13 +97,13 @@
     (-get-level [_] 10)
 
     p/Monad
-    (mreturn [_ v]
-      (d/pair v (p/mempty b/vector-context)))
+    (-mreturn [_ v]
+      (d/pair v (p/-mempty b/vector-context)))
 
-    (mbind [_ mv f]
+    (-mbind [_ mv f]
       (let [[v log] mv
             [v' log'] (f v)]
-        (d/pair v' (p/mappend (p/get-context log) log log'))))
+        (d/pair v' (p/-mappend (p/-get-context log) log log'))))
 
     MonadWriter
     (-tell [_ v]
@@ -128,53 +128,53 @@
     (-get-level [_] 100)
 
     p/Monad
-    (mreturn [_ v]
-      (p/mreturn inner-context
-                 (d/pair v (p/mempty b/vector-context))))
+    (-mreturn [_ v]
+      (p/-mreturn inner-context
+                 (d/pair v (p/-mempty b/vector-context))))
 
-    (mbind [_ mv f]
-      (p/mbind inner-context
-               mv
-               (fn [[v log]]
-                 (p/mbind inner-context
-                          (f v)
-                          (fn [[v' log']]
-                                   (p/mreturn inner-context
-                                              (d/pair v' (p/mappend (p/get-context log) log log'))))))))
+    (-mbind [_ mv f]
+      (p/-mbind inner-context
+                mv
+                (fn [[v log]]
+                  (p/-mbind inner-context
+                            (f v)
+                            (fn [[v' log']]
+                              (p/-mreturn inner-context
+                                          (d/pair v' (p/-mappend (p/-get-context log) log log'))))))))
 
     MonadWriter
     (-tell [_ v]
-      (p/mreturn inner-context (d/pair nil [v])))
+      (p/-mreturn inner-context (d/pair nil [v])))
 
     (-listen [_ mv]
-      (p/mbind inner-context
-               mv
-               (fn [mv]
-                 (p/mreturn inner-context
-                            (d/pair mv (second mv))))))
+      (p/-mbind inner-context
+                mv
+                (fn [mv]
+                  (p/-mreturn inner-context
+                              (d/pair mv (second mv))))))
 
     (-pass [_ mv]
-      (p/mbind inner-context
-               mv
-               (fn [w]
-                 (let [[v f] (first w)
-                       log   (second w)]
-                   (p/mreturn inner-context
-                              (d/pair v (f log)))))))
+      (p/-mbind inner-context
+                mv
+                (fn [w]
+                  (let [[v f] (first w)
+                        log   (second w)]
+                    (p/-mreturn inner-context
+                                (d/pair v (f log)))))))
 
     p/MonadTrans
-    (base [_]
+    (-base [_]
       context)
 
-    (inner [_]
+    (-inner [_]
       inner-context)
 
-    (lift [_ mv]
-      (p/mbind inner-context
-                   mv
-                   (fn [v]
-                     (p/mreturn inner-context
-                                    (d/pair v (p/mempty b/vector-context))))))))
+    (-lift [_ mv]
+      (p/-mbind inner-context
+                mv
+                (fn [v]
+                  (p/-mreturn inner-context
+                              (d/pair v (p/-mempty b/vector-context))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Writer monad functions

--- a/src/cats/monad/either.cljc
+++ b/src/cats/monad/either.cljc
@@ -43,11 +43,11 @@
 ;; Type constructor and functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(declare either-monad)
+(declare context)
 
 (deftype Right [v]
   p/Context
-  (get-context [_] either-monad)
+  (get-context [_] context)
 
   p/Extract
   (extract [_] v)
@@ -75,7 +75,7 @@
 
 (deftype Left [v]
   p/Context
-  (get-context [_] either-monad)
+  (get-context [_] context)
 
   p/Extract
   (extract [_] v)
@@ -131,7 +131,7 @@
   of Either monad."
   [v]
   (if (satisfies? p/Context v)
-    (identical? (p/get-context v) either-monad)
+    (identical? (p/get-context v) context)
     false))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -139,8 +139,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def ^{:no-doc true}
-  either-monad
+  context
   (reify
+    p/ContextClass
+    (-get-level [_] 10)
+
     p/Functor
     (fmap [_ f s]
       (if (right? s)
@@ -185,6 +188,9 @@
   "The Either transformer constructor."
   [inner-monad]
   (reify
+    p/ContextClass
+    (-get-level [_] 100)
+
     p/Monad
     (mreturn [_ v]
       (p/mreturn inner-monad (right v)))
@@ -199,7 +205,7 @@
 
     p/MonadTrans
     (base [_]
-      either-monad)
+      context)
 
     (inner [_]
       inner-monad)
@@ -240,8 +246,7 @@
   either is a left, return it."
   [e rf]
   {:pre [(either? e)]}
-  (let [context either-monad]
-    (p/mbind context e rf)))
+  (p/mbind context e rf))
 
 (def lefts
   "Given a collection of eithers, return only the values that are left."

--- a/src/cats/monad/either.cljc
+++ b/src/cats/monad/either.cljc
@@ -37,7 +37,8 @@
       (either/left 1)
       ;; => #<Left [1]>
   "
-  (:require [cats.protocols :as p]))
+  (:require [cats.protocols :as p]
+            [cats.context :as ctx]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Type constructor and functions
@@ -142,7 +143,7 @@
   context
   (reify
     p/ContextClass
-    (-get-level [_] 10)
+    (-get-level [_] ctx/+level-default+)
 
     p/Functor
     (-fmap [_ f s]
@@ -189,7 +190,7 @@
   [inner-monad]
   (reify
     p/ContextClass
-    (-get-level [_] 100)
+    (-get-level [_] ctx/+level-transformer+)
 
     p/Monad
     (-mreturn [_ v]

--- a/src/cats/monad/either.cljc
+++ b/src/cats/monad/either.cljc
@@ -47,10 +47,10 @@
 
 (deftype Right [v]
   p/Context
-  (get-context [_] context)
+  (-get-context [_] context)
 
   p/Extract
-  (extract [_] v)
+  (-extract [_] v)
 
   #?(:clj clojure.lang.IDeref
      :cljs IDeref)
@@ -75,10 +75,10 @@
 
 (deftype Left [v]
   p/Context
-  (get-context [_] context)
+  (-get-context [_] context)
 
   p/Extract
-  (extract [_] v)
+  (-extract [_] v)
 
   #?(:clj clojure.lang.IDeref
      :cljs IDeref)
@@ -131,7 +131,7 @@
   of Either monad."
   [v]
   (if (satisfies? p/Context v)
-    (identical? (p/get-context v) context)
+    (identical? (p/-get-context v) context)
     false))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -145,38 +145,38 @@
     (-get-level [_] 10)
 
     p/Functor
-    (fmap [_ f s]
+    (-fmap [_ f s]
       (if (right? s)
         (right (f (.-v s)))
         s))
 
     p/Applicative
-    (pure [_ v]
+    (-pure [_ v]
       (right v))
 
-    (fapply [m af av]
+    (-fapply [m af av]
       (if (right? af)
-        (p/fmap m (.-v af) av)
+        (p/-fmap m (.-v af) av)
         af))
 
     p/Monad
-    (mreturn [_ v]
+    (-mreturn [_ v]
       (right v))
 
-    (mbind [_ s f]
+    (-mbind [_ s f]
       (if (right? s)
         (f (.-v s))
         s))
 
     p/Foldable
-    (foldl [_ f z mv]
+    (-foldl [_ f z mv]
       (if (right? mv)
-        (f z (p/extract mv))
+        (f z (p/-extract mv))
         z))
 
-    (foldr [_ f z mv]
+    (-foldr [_ f z mv]
       (if (right? mv)
-        (f (p/extract mv) z)
+        (f (p/-extract mv) z)
         z))))
 
 
@@ -192,29 +192,29 @@
     (-get-level [_] 100)
 
     p/Monad
-    (mreturn [_ v]
-      (p/mreturn inner-monad (right v)))
+    (-mreturn [_ v]
+      (p/-mreturn inner-monad (right v)))
 
-    (mbind [_ mv f]
-      (p/mbind inner-monad
-               mv
-               (fn [either-v]
-                 (if (left? either-v)
-                   (p/mreturn inner-monad either-v)
-                   (f (p/extract either-v))))))
+    (-mbind [_ mv f]
+      (p/-mbind inner-monad
+                mv
+                (fn [either-v]
+                  (if (left? either-v)
+                    (p/-mreturn inner-monad either-v)
+                    (f (p/-extract either-v))))))
 
     p/MonadTrans
-    (base [_]
+    (-base [_]
       context)
 
-    (inner [_]
+    (-inner [_]
       inner-monad)
 
-    (lift [m mv]
-      (p/mbind inner-monad
-               mv
-               (fn [v]
-                 (p/mreturn inner-monad (right v)))))))
+    (-lift [m mv]
+      (p/-mbind inner-monad
+                mv
+                (fn [v]
+                  (p/-mreturn inner-monad (right v)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Utility functions
@@ -227,8 +227,8 @@
   [e lf rf]
   {:pre [(either? e)]}
   (if (left? e)
-    (lf (p/extract e))
-    (rf (p/extract e))))
+    (lf (p/-extract e))
+    (rf (p/-extract e))))
 
 (defn branch-left
   "Given an either value and a function, if the either is a
@@ -246,7 +246,7 @@
   either is a left, return it."
   [e rf]
   {:pre [(either? e)]}
-  (p/mbind context e rf))
+  (p/-mbind context e rf))
 
 (def lefts
   "Given a collection of eithers, return only the values that are left."
@@ -269,5 +269,5 @@
   [e]
   {:pre [(either? e)]}
   (if (left? e)
-    (right (p/extract e))
-    (left (p/extract e))))
+    (right (p/-extract e))
+    (left (p/-extract e))))

--- a/src/cats/monad/exception.cljc
+++ b/src/cats/monad/exception.cljc
@@ -80,10 +80,10 @@
 
 (deftype Success [v]
   p/Context
-  (get-context [_] context)
+  (-get-context [_] context)
 
   p/Extract
-  (extract [_] v)
+  (-extract [_] v)
 
   #?(:clj clojure.lang.IDeref
      :cljs IDeref)
@@ -108,10 +108,10 @@
 
 (deftype Failure [e]
   p/Context
-  (get-context [_] context)
+  (-get-context [_] context)
 
   p/Extract
-  (extract [_] e)
+  (-extract [_] e)
 
   #?(:clj clojure.lang.IDeref
      :cljs IDeref)
@@ -179,7 +179,7 @@
   of Exception monad."
   [v]
   (if (satisfies? p/Context v)
-    (identical? (p/get-context v) context)
+    (identical? (p/-get-context v) context)
     false))
 
 (defn extract
@@ -196,12 +196,12 @@
   ([mv]
    {:pre [(exception? mv)]}
    (if (success? mv)
-     (p/extract mv)
-     (throw (p/extract mv))))
+     (p/-extract mv)
+     (throw (p/-extract mv))))
   ([mv default]
    {:pre [(exception? mv)]}
    (if (success? mv)
-     (p/extract mv)
+     (p/-extract mv)
      default)))
 
 (defn ^{:no-doc true}
@@ -275,25 +275,25 @@
     (-get-level [_] 10)
 
     p/Functor
-    (fmap [_ f s]
+    (-fmap [_ f s]
       (if (success? s)
-        (try-on (f (p/extract s)))
+        (try-on (f (p/-extract s)))
         s))
 
     p/Applicative
-    (pure [_ v]
+    (-pure [_ v]
       (success v))
 
-    (fapply [m af av]
+    (-fapply [m af av]
       (if (success? af)
-        (p/fmap m (p/extract af) av)
+        (p/-fmap m (p/-extract af) av)
         af))
 
     p/Monad
-    (mreturn [_ v]
+    (-mreturn [_ v]
       (success v))
 
-    (mbind [_ s f]
+    (-mbind [_ s f]
       (if (success? s)
-        (f (p/extract s))
+        (f (p/-extract s))
         s))))

--- a/src/cats/monad/exception.cljc
+++ b/src/cats/monad/exception.cljc
@@ -76,11 +76,11 @@
 ;; Types and implementations.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(declare exception-monad)
+(declare context)
 
 (deftype Success [v]
   p/Context
-  (get-context [_] exception-monad)
+  (get-context [_] context)
 
   p/Extract
   (extract [_] v)
@@ -108,7 +108,7 @@
 
 (deftype Failure [e]
   p/Context
-  (get-context [_] exception-monad)
+  (get-context [_] context)
 
   p/Extract
   (extract [_] e)
@@ -179,7 +179,7 @@
   of Exception monad."
   [v]
   (if (satisfies? p/Context v)
-    (identical? (p/get-context v) exception-monad)
+    (identical? (p/get-context v) context)
     false))
 
 (defn extract
@@ -228,7 +228,7 @@
   exec-try-or-recover
   [func recoverfn]
   (let [result (exec-try-on func)]
-    (ctx/with-context exception-monad
+    (ctx/with-context context
       (if (failure? result)
         (recoverfn (.-e result))
         result))))
@@ -269,8 +269,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def ^{:no-doc true}
-  exception-monad
+  context
   (reify
+    p/ContextClass
+    (-get-level [_] 10)
+
     p/Functor
     (fmap [_ f s]
       (if (success? s)

--- a/src/cats/monad/exception.cljc
+++ b/src/cats/monad/exception.cljc
@@ -272,7 +272,7 @@
   context
   (reify
     p/ContextClass
-    (-get-level [_] 10)
+    (-get-level [_] ctx/+level-default+)
 
     p/Functor
     (-fmap [_ f s]

--- a/src/cats/monad/identity.cljc
+++ b/src/cats/monad/identity.cljc
@@ -25,8 +25,9 @@
 
 (ns cats.monad.identity
   "The Identity Monad."
-  (:require [cats.protocols :as p])
-  (:refer-clojure :exclude [identity]))
+  (:refer-clojure :exclude [identity])
+  (:require [cats.protocols :as p]
+            [cats.context :as ctx]))
 
 (declare context)
 
@@ -77,7 +78,7 @@
   context
   (reify
     p/ContextClass
-    (-get-level [_] 10)
+    (-get-level [_] ctx/+level-default+)
 
     p/Functor
     (-fmap [_ f iv]
@@ -106,7 +107,7 @@
   [inner-monad]
   (reify
     p/ContextClass
-    (-get-level [_] 100)
+    (-get-level [_] ctx/+level-transformer+)
 
     p/Monad
     (-mreturn [_ v]

--- a/src/cats/monad/identity.cljc
+++ b/src/cats/monad/identity.cljc
@@ -36,10 +36,10 @@
 
 (deftype Identity [v]
   p/Context
-  (get-context [_] context)
+  (-get-context [_] context)
 
   p/Extract
-  (extract [_] v)
+  (-extract [_] v)
 
   #?(:clj clojure.lang.IDeref
      :cljs IDeref)
@@ -80,21 +80,21 @@
     (-get-level [_] 10)
 
     p/Functor
-    (fmap [_ f iv]
+    (-fmap [_ f iv]
       (Identity. (f (.-v iv))))
 
     p/Applicative
-    (pure [_ v]
+    (-pure [_ v]
       (Identity. v))
 
-    (fapply [_ af av]
+    (-fapply [_ af av]
       (Identity. ((.-v af) (.-v av))))
 
     p/Monad
-    (mreturn [_ v]
+    (-mreturn [_ v]
       (Identity. v))
 
-    (mbind [_ mv f]
+    (-mbind [_ mv f]
       (f (.-v mv)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -109,8 +109,8 @@
     (-get-level [_] 100)
 
     p/Monad
-    (mreturn [_ v]
-      (identity (p/mreturn inner-monad v)))
+    (-mreturn [_ v]
+      (identity (p/-mreturn inner-monad v)))
 
-    (mbind [_ mv f]
+    (-mbind [_ mv f]
       nil)))

--- a/src/cats/monad/identity.cljc
+++ b/src/cats/monad/identity.cljc
@@ -28,7 +28,7 @@
   (:require [cats.protocols :as p])
   (:refer-clojure :exclude [identity]))
 
-(declare identity-monad)
+(declare context)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Type constructors
@@ -36,7 +36,7 @@
 
 (deftype Identity [v]
   p/Context
-  (get-context [_] identity-monad)
+  (get-context [_] context)
 
   p/Extract
   (extract [_] v)
@@ -74,8 +74,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def ^{:no-doc true}
-  identity-monad
+  context
   (reify
+    p/ContextClass
+    (-get-level [_] 10)
+
     p/Functor
     (fmap [_ f iv]
       (Identity. (f (.-v iv))))
@@ -102,6 +105,9 @@
   "The Identity transformer constructor."
   [inner-monad]
   (reify
+    p/ContextClass
+    (-get-level [_] 100)
+
     p/Monad
     (mreturn [_ v]
       (identity (p/mreturn inner-monad v)))

--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -34,7 +34,7 @@
   "
   (:require [cats.protocols :as p]))
 
-(declare maybe-monad)
+(declare context)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Type constructors and functions
@@ -42,7 +42,7 @@
 
 (deftype Just [v]
   p/Context
-  (get-context [_] maybe-monad)
+  (get-context [_] context)
 
   p/Extract
   (extract [_] v)
@@ -70,7 +70,7 @@
 
 (deftype Nothing []
   p/Context
-  (get-context [_] maybe-monad)
+  (get-context [_] context)
 
   p/Extract
   (extract [_] nil)
@@ -100,7 +100,7 @@
   of Maybe monad."
   [v]
   (if (satisfies? p/Context v)
-    (identical? (p/get-context v) maybe-monad)
+    (identical? (p/get-context v) context)
     false))
 
 (defn just
@@ -163,8 +163,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def ^{:no-doc true}
-  maybe-monad
+  context
   (reify
+    p/ContextClass
+    (-get-level [_] 10)
+
     p/Semigroup
     (mappend [ctx mv mv']
       (cond
@@ -229,10 +232,13 @@
   "The maybe transformer constructor."
   [inner-monad]
   (reify
+    p/ContextClass
+    (-get-level [_] 100)
+
     p/Functor
     (fmap [_ f fv]
       (p/fmap inner-monad
-              #(p/fmap maybe-monad f %)
+              #(p/fmap context f %)
               fv))
 
     p/Monad
@@ -262,7 +268,7 @@
 
     p/MonadTrans
     (base [_]
-      maybe-monad)
+      context)
 
     (inner [_]
       inner-monad)

--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -32,7 +32,8 @@
       (maybe/just 1)
       ;; => #<Just [1]>
   "
-  (:require [cats.protocols :as p]))
+  (:require [cats.protocols :as p]
+            [cats.context :as ctx]))
 
 (declare context)
 
@@ -166,7 +167,7 @@
   context
   (reify
     p/ContextClass
-    (-get-level [_] 10)
+    (-get-level [_] ctx/+level-default+)
 
     p/Semigroup
     (-mappend [ctx mv mv']
@@ -233,7 +234,7 @@
   [inner-monad]
   (reify
     p/ContextClass
-    (-get-level [_] 100)
+    (-get-level [_] ctx/+level-transformer+)
 
     p/Functor
     (-fmap [_ f fv]

--- a/src/cats/protocols.cljc
+++ b/src/cats/protocols.cljc
@@ -31,6 +31,10 @@
   to be used directly. Is a private api but exposes
   as public for documentation purposes.")
 
+(defprotocol ContextClass
+  "Is a marker protocol for context classes."
+  (-get-level [_] "Get a context priority level."))
+
 (defprotocol Context
   "Abstraction that establish a membership of types
   with one concrete monad.

--- a/src/cats/protocols.cljc
+++ b/src/cats/protocols.cljc
@@ -45,57 +45,57 @@
   A great example es Maybe monad type Just. It implements
   this abstraction for establish that Just is part of
   Maybe monad."
-  (get-context [_] "Get the monad instance for curent value."))
+  (-get-context [_] "Get the monad instance for curent value."))
 
 (defprotocol Semigroup
   "A structure with an associative binary operation."
-  (mappend [s sv sv'] "An associative addition operation."))
+  (-mappend [s sv sv'] "An associative addition operation."))
 
 (defprotocol Monoid
   "A Semigroup which has an identity element for is associative binary operation."
-  (mempty [s] "The identity element for the given monoid."))
+  (-mempty [s] "The identity element for the given monoid."))
 
 (defprotocol Extract
   "A type class responsible of extract the
   value from a monad context."
-  (extract [mv] "Extract the value from monad context."))
+  (-extract [mv] "Extract the value from monad context."))
 
 (defprotocol Functor
   "A data type that can be mapped over without altering its context."
-  (fmap [ftor f fv] "Applies function f to the value(s) inside the context of the functor fv."))
+  (-fmap [ftor f fv] "Applies function f to the value(s) inside the context of the functor fv."))
 
 (defprotocol Applicative
   "The Applicative abstraction."
-  (fapply [app af av]
+  (-fapply [app af av]
     "Applies the function(s) inside af's context to the value(s)
      inside av's context while preserving the context.")
-  (pure [app v]
+  (-pure [app v]
     "Takes any context monadic value ctx and any value v, and puts
      the value v in the most minimal context of same type of ctx"))
 
 (defprotocol Foldable
   "Abstraction of data structures that can be folded to a summary value."
-  (foldl [fctx f z xs] "Left-associative fold of a structure.")
-  (foldr [fctx f z xs] "Right-associative fold of a structure."))
+  (-foldl [fctx f z xs] "Left-associative fold of a structure.")
+  (-foldr [fctx f z xs] "Right-associative fold of a structure."))
 
 (defprotocol Monad
   "The Monad abstraction."
-  (mreturn [m v])
-  (mbind [m mv f]))
+  (-mreturn [m v])
+  (-mbind [m mv f]))
 
 (defprotocol MonadZero
   "A complement abstraction for monad that
   supports the notion of an identity element."
-  (mzero [m] "The identity element for the given monadzero."))
+  (-mzero [m] "The identity element for the given monadzero."))
 
 (defprotocol MonadPlus
   "A complement abstraction for Monad that
   supports the notion of addition."
-  (mplus [m mv mv'] "An associative addition operation."))
+  (-mplus [m mv mv'] "An associative addition operation."))
 
 (defprotocol MonadTrans
   "A common abstraction for all monad transformers."
-  (base [mt] "Return the base monad of this transformer.")
-  (inner [mt] "Return the monad that this transformer wraps.")
-  (lift [m mv]
+  (-base [mt] "Return the base monad of this transformer.")
+  (-inner [mt] "Return the monad that this transformer wraps.")
+  (-lift [m mv]
     "Lift a value from the parameterized monad to the transformer."))

--- a/test/cats/applicative/validation_spec.cljc
+++ b/test/cats/applicative/validation_spec.cljc
@@ -5,6 +5,7 @@
                [cats.protocols :as p]
                [cats.applicative.validation :as validation]
                [cats.monad.either :as either]
+               [cats.context :as ctx :include-macros true]
                [cats.core :as m :include-macros true])
      :clj
      (:require [clojure.test :as t]
@@ -12,6 +13,7 @@
                [cats.protocols :as p]
                [cats.applicative.validation :as validation]
                [cats.monad.either :as either]
+               [cats.context :as ctx]
                [cats.core :as m])))
 
 (t/deftest basic-operations-test
@@ -45,7 +47,7 @@
              (m/mappend ok1 ok2)))))
 
 (t/deftest monoid-test
-  (m/with-monad validation/validation-applicative
+  (ctx/with-context validation/context
     (t/is (= (validation/fail) (m/mempty)))))
 
 (t/deftest functor-test

--- a/test/cats/builtin_spec.cljc
+++ b/test/cats/builtin_spec.cljc
@@ -19,6 +19,14 @@
   (t/testing "extract function"
     (t/is (= (p/extract nil) nil))))
 
+(t/deftest map-tests
+  (t/testing "Map as monoid"
+    (t/is (= (m/mempty b/map-monoid) {})))
+  (t/testing "Map as semigroup"
+    (t/is (= (m/mappend "1" "2") "12"))
+    (t/is (= (m/mappend (m/mempty b/map-monoid) "1") "1"))))
+
+
 (t/deftest vector-monad
   (t/testing "Forms a semigroup"
     (t/is (= [1 2 3 4 5]

--- a/test/cats/builtin_spec.cljc
+++ b/test/cats/builtin_spec.cljc
@@ -3,11 +3,14 @@
             [cats.protocols :as p]
             [cats.monad.maybe :as maybe]
 
+            #?(:cljs [cats.context :as ctx :include-macros true]
+               :clj  [cats.context :as ctx])
+
             #?(:cljs [cljs.test :as t]
-               :clj [clojure.test :as t])
+               :clj  [clojure.test :as t])
 
             #?(:cljs [cats.core :as m :include-macros true]
-               :clj [cats.core :as m])))
+               :clj  [cats.core :as m])))
 
 (t/deftest test-nil-as-maybe
   (t/testing "Nil works like nothing (for avoid unnecesary null pointers)."
@@ -21,11 +24,17 @@
 
 (t/deftest map-tests
   (t/testing "Map as monoid"
-    (t/is (= (m/mempty b/map-monoid) {})))
+    (t/is (= (m/mempty b/map-context) {})))
   (t/testing "Map as semigroup"
-    (t/is (= (m/mappend "1" "2") "12"))
-    (t/is (= (m/mappend (m/mempty b/map-monoid) "1") "1"))))
+    (t/is (= (m/mappend {:a 1} {:b 2}) {:a 1 :b 2}))
+    (t/is (= (m/mappend (m/mempty b/map-context) {:a 1}) {:a 1}))))
 
+;; (t/deftest string-tests
+;;   (t/testing "String as monoid"
+;;     (t/is (= (m/mempty b/string-context) "")))
+;;   (t/testing "Map as semigroup"
+;;     (t/is (= (m/mappend "1" "2") "12"))
+;;     (t/is (= (m/mappend (m/mempty b/string-context) "1") "1"))))
 
 (t/deftest vector-monad
   (t/testing "Forms a semigroup"
@@ -34,7 +43,7 @@
 
   (t/testing "Forms a monoid"
     (t/is (= [1 2 3]
-             (m/with-monad b/vector-monad
+             (ctx/with-context b/vector-context
                (m/mappend [1 2 3] (m/mempty))))))
 
   (t/testing "The first monad law: left identity"
@@ -66,11 +75,11 @@
 
     (t/testing "Forms a monoid"
       (t/is (= [1 2 3]
-               (m/with-monad b/sequence-monad
+               (ctx/with-context b/sequence-context
                  (m/mappend (lazy-seq [1 2 3]) (m/mempty))))))
 
     (t/testing "The first monad law: left identity"
-      (t/is (= s (m/with-monad b/sequence-monad
+      (t/is (= s (ctx/with-context b/sequence-context
                    (m/>>= (m/return 2)
                           val->lazyseq)))))
 
@@ -95,7 +104,7 @@
 
   (t/testing "Forms a monoid"
     (t/is (= #{1 2 3}
-             (m/with-monad b/set-monad
+             (ctx/with-context b/set-context
                (m/mappend #{1 2 3} (m/mempty))))))
 
 
@@ -104,7 +113,7 @@
              (m/fmap inc #{1 2 3}))))
 
   (t/testing "The first monad law: left identity"
-    (t/is (= #{2} (m/with-monad b/set-monad
+    (t/is (= #{2} (ctx/with-context b/set-context
                     (m/>>= (m/return 2)
                            (fn [x] #{x}))))))
 

--- a/test/cats/builtin_spec.cljc
+++ b/test/cats/builtin_spec.cljc
@@ -20,7 +20,7 @@
     (t/is (maybe/maybe? nil)))
 
   (t/testing "extract function"
-    (t/is (= (p/extract nil) nil))))
+    (t/is (= (m/extract nil) nil))))
 
 (t/deftest map-tests
   (t/testing "Map as monoid"

--- a/test/cats/labs/continuation_spec.cljc
+++ b/test/cats/labs/continuation_spec.cljc
@@ -5,6 +5,7 @@
                [cats.protocols :as p]
                [cats.labs.continuation :as cont]
                [cats.monad.maybe :as maybe]
+               [cats.context :as ctx :include-macros true]
                [cats.core :as m :include-macros true])
      :clj
      (:require [clojure.test :as t]
@@ -12,6 +13,7 @@
                [cats.protocols :as p]
                [cats.labs.continuation :as cont]
                [cats.monad.maybe :as maybe]
+               [cats.context :as ctx]
                [cats.core :as m])))
 
 (def cont-42 (cont/continuation (fn [c] (c 42))))
@@ -20,7 +22,7 @@
 
 (t/deftest first-monad-law-left-identity
   (t/is (= (cont/run-cont cont-42)
-           (cont/run-cont (m/with-monad cont/continuation-monad
+           (cont/run-cont (ctx/with-context cont/context
                             (m/>>= (m/return 42)
                                    (fn [v] (cont/continuation (fn [c] c v)))))))))
 

--- a/test/cats/labs/reader_spec.cljc
+++ b/test/cats/labs/reader_spec.cljc
@@ -5,6 +5,7 @@
                [cats.protocols :as p]
                [cats.labs.reader :as reader]
                [cats.monad.maybe :as maybe]
+               [cats.context :as ctx :include-macros true]
                [cats.core :as m :include-macros true])
      :clj
      (:require [clojure.test :as t]
@@ -12,6 +13,7 @@
                [cats.protocols :as p]
                [cats.labs.reader :as reader]
                [cats.monad.maybe :as maybe]
+               [cats.context :as ctx]
                [cats.core :as m])))
 
 (t/deftest access-to-the-environment-test
@@ -27,25 +29,25 @@
   (t/is (= 42 (reader/run-reader (m/fmap inc reader/ask) 41))))
 
 
-(def maybe-reader-t (reader/reader-transformer maybe/maybe-monad))
+(def maybe-reader-t (reader/reader-transformer maybe/context))
 
 (t/deftest reader-transformerformer-tests
   ;; The `ask` reader gives you access to the environment
   (t/is (= (maybe/just {:foo "bar"})
-           (m/with-monad maybe-reader-t
+           (ctx/with-context maybe-reader-t
              (reader/run-reader reader/ask {:foo "bar"}))))
 
   ;; The `local` function allows you to run readers in a modified environment
   (t/is (= (maybe/just 42)
-           (m/with-monad maybe-reader-t
+           (ctx/with-context maybe-reader-t
              (reader/run-reader (reader/local inc reader/ask) 41))))
 
   ;; Monadic values can be lifted to the reader transformer
   (t/is (= (maybe/just 42)
-           (m/with-monad maybe-reader-t
+           (ctx/with-context maybe-reader-t
              (reader/run-reader (m/lift (maybe/just 42)) {}))))
 
   ;; The monad transformer values can be mapped over
   (t/is (= (maybe/just 42)
-           (m/with-monad maybe-reader-t
+           (ctx/with-context maybe-reader-t
              (reader/run-reader (m/fmap inc reader/ask) 41)))))

--- a/test/cats/labs/state_spec.cljc
+++ b/test/cats/labs/state_spec.cljc
@@ -6,6 +6,7 @@
                [cats.data :as d]
                [cats.labs.state :as state]
                [cats.monad.maybe :as maybe]
+               [cats.context :as ctx :include-macros true]
                [cats.core :as m :include-macros true])
      :clj
      (:require [clojure.test :as t]
@@ -14,6 +15,7 @@
                [cats.data :as d]
                [cats.labs.state :as state]
                [cats.monad.maybe :as maybe]
+               [cats.context :as ctx]
                [cats.core :as m])))
 
 (t/deftest get-state-should-return-the-identity-test
@@ -52,29 +54,29 @@
 
 
 (def state-maybe-t
-  (state/state-transformer maybe/maybe-monad))
+  (state/state-transformer maybe/context))
 
 (t/deftest state-transformer-tests
   ;; get-state should return the identity wrapped in the inner monad's context.
   (t/is (= (maybe/just (d/pair :foo :foo))
-           (m/with-monad state-maybe-t
+           (ctx/with-context state-maybe-t
              (state/run-state (state/get-state) :foo))))
 
   ;; swap-state should should apply function to state and return it.
   (t/is (= (maybe/just (d/pair 1 2))
-           (m/with-monad state-maybe-t
+           (ctx/with-context state-maybe-t
              (state/run-state (state/swap-state inc) 1))))
 
   ;; put-state should override the state
   (t/is (= (maybe/just (d/pair 0 42))
-           (m/with-monad state-maybe-t
+           (ctx/with-context state-maybe-t
              (state/run-state (state/put-state 42) 0))))
 
   ;; State monad composition with mlet should return state
   (let [res (m/mlet [s (state/get-state)]
               (m/return (inc s)))]
     (t/is (state/state? res))
-    (let [mres (m/with-monad state-maybe-t
+    (let [mres (ctx/with-context state-maybe-t
                  (state/run-state res 1))
           res  (maybe/from-maybe mres)]
       (t/is (maybe/maybe? mres))
@@ -86,7 +88,7 @@
   (let [res (m/mlet [s (state/get-state)]
               (m/return (inc s)))]
     (t/is (state/state? res))
-    (let [mres (m/with-monad state-maybe-t
+    (let [mres (ctx/with-context state-maybe-t
                  (state/run-state (m/fmap inc res) 1))
           res (maybe/from-maybe mres)]
       (t/is (maybe/maybe? mres))
@@ -102,8 +104,8 @@
                                 i (m/lift (maybe/nothing))]
                          (m/return (+ s i)))]
     (t/is (= (maybe/just (d/pair 45 42))
-             (m/with-monad state-maybe-t
+             (ctx/with-context state-maybe-t
                (state/run-state lifted-just 42))))
     (t/is (= (maybe/nothing)
-             (m/with-monad state-maybe-t
+             (ctx/with-context state-maybe-t
                (state/run-state lifted-nothing nil))))))

--- a/test/cats/labs/writer_spec.cljc
+++ b/test/cats/labs/writer_spec.cljc
@@ -6,6 +6,7 @@
                [cats.data :as d]
                [cats.labs.writer :as writer]
                [cats.monad.maybe :as maybe]
+               [cats.context :as ctx :include-macros true]
                [cats.core :as m :include-macros true])
      :clj
      (:require [clojure.test :as t]
@@ -14,21 +15,22 @@
                [cats.data :as d]
                [cats.labs.writer :as writer]
                [cats.monad.maybe :as maybe]
+               [cats.context :as ctx]
                [cats.core :as m])))
 
 (t/deftest writer-monad-tests
   ;; Putting a value in a writer context yields an empty log
-  (t/is (= 42 (writer/value (p/mreturn writer/writer-monad 42))))
-  (t/is (= [] (writer/log (p/mreturn writer/writer-monad 42))))
+  (t/is (= 42 (writer/value (p/mreturn writer/context 42))))
+  (t/is (= [] (writer/log (p/mreturn writer/context 42))))
 
   ;; The `tell` function adds the given value to the log
   (t/is (= ["Hello" "world"]
-           (m/with-monad writer/writer-monad
+           (ctx/with-context writer/context
              (writer/log (m/>> (writer/tell "Hello")
                                (writer/tell "world"))))))
 
   ;; The `listen` function yields a pair with the value and the log
-  (let [w (m/with-monad writer/writer-monad
+  (let [w (ctx/with-context writer/context
             (m/>> (writer/tell "Hello")
                   (writer/tell "world")
                   (m/return 42)))
@@ -39,7 +41,7 @@
              (second w))))
 
   ;; The `pass` function can be used to apply a function to the log
-  (let [w (m/with-monad writer/writer-monad
+  (let [w (ctx/with-context writer/context
             (m/>> (writer/tell "Hello")
                   (writer/tell "world")
                   (m/return [42 reverse])))
@@ -50,7 +52,7 @@
              (second w))))
 
   ;; The log values are accumulated using Semigroup's `mappend` operation
-  (let [w (m/with-monad writer/writer-monad
+  (let [w (ctx/with-context writer/context
             (m/>> (writer/pass (m/return [42 set]))
                   (writer/tell "Hello")
                   (writer/tell "Hello")
@@ -63,28 +65,28 @@
              (second w)))))
 
 
-(def writer-maybe-t (writer/writer-transformer maybe/maybe-monad))
+(def writer-maybe-t (writer/writer-transformer maybe/context))
 
 (t/deftest writer-transformer-tests
   ;; Putting a value in a writer transformer context yields an empty log
-  (let [w (m/with-monad writer-maybe-t
+  (let [w (ctx/with-context writer-maybe-t
             (m/return 42))]
     (t/is (= 42 (writer/value (maybe/from-maybe w))))
     (t/is (= [] (writer/log (maybe/from-maybe w)))))
 
   ;; The `tell` function adds the given value to the log
-  (let [w (m/with-monad writer-maybe-t
+  (let [w (ctx/with-context writer-maybe-t
             (m/>> (writer/tell "Hello")
                   (writer/tell "world")))]
     (t/is (= ["Hello" "world"]
              (writer/log (maybe/from-maybe w)))))
 
   ;; The `listen` function yields a pair with the value and the log
-  (let [w (m/with-monad writer-maybe-t
+  (let [w (ctx/with-context writer-maybe-t
             (m/>> (writer/tell "Hello")
                   (writer/tell "world")
                   (m/return 42)))
-        w (m/with-monad writer-maybe-t
+        w (ctx/with-context writer-maybe-t
             (writer/listen w))]
     (t/is (= (d/pair 42 ["Hello" "world"])
              (first (maybe/from-maybe w))))
@@ -92,11 +94,11 @@
              (second (maybe/from-maybe w)))))
 
   ;; The `pass` function can be used to apply a function to the log
-  (let [w (m/with-monad writer-maybe-t
+  (let [w (ctx/with-context writer-maybe-t
             (m/>> (writer/tell "Hello")
                   (writer/tell "world")
                   (m/return [42 reverse])))
-        w (m/with-monad writer-maybe-t
+        w (ctx/with-context writer-maybe-t
             (writer/listen (writer/pass w)))]
     (t/is (= (d/pair 42 ["world" "Hello"])
              (first (maybe/from-maybe w))))
@@ -104,7 +106,7 @@
              (second (maybe/from-maybe w)))))
 
   ;; The log values are accumulated using Semigroup's `mappend` operation
-  (let [w (m/with-monad writer-maybe-t
+  (let [w (ctx/with-context writer-maybe-t
             (m/>> (writer/pass (m/return [42 set]))
                   (writer/tell "Hello")
                   (writer/tell "Hello")
@@ -112,21 +114,21 @@
                   (writer/tell "world")
                   (writer/tell "Hello")
                   (writer/tell "world")))
-        w (m/with-monad writer-maybe-t
+        w (ctx/with-context writer-maybe-t
             (writer/listen w))]
     (t/is (= #{"world" "Hello"}
              (second (maybe/from-maybe w)))))
 
   ;; Inner monad values can be lifted into the transformer
-  (let [lifted-just (m/with-monad writer-maybe-t
+  (let [lifted-just (ctx/with-context writer-maybe-t
                       (m/lift (maybe/just 3)))
-        lifted-nothing (m/with-monad writer-maybe-t
+        lifted-nothing (ctx/with-context writer-maybe-t
                          (m/lift (maybe/nothing)))]
     (t/is (= (maybe/just (d/pair 3 ["Hello"]))
-             (m/with-monad writer-maybe-t
+             (ctx/with-context writer-maybe-t
                (m/>> (writer/tell "Hello")
                      lifted-just))))
     (t/is (= (maybe/nothing)
-             (m/with-monad writer-maybe-t
+             (ctx/with-context writer-maybe-t
                (m/>> (writer/tell "Hello")
                      lifted-nothing))))))

--- a/test/cats/labs/writer_spec.cljc
+++ b/test/cats/labs/writer_spec.cljc
@@ -20,8 +20,8 @@
 
 (t/deftest writer-monad-tests
   ;; Putting a value in a writer context yields an empty log
-  (t/is (= 42 (writer/value (p/mreturn writer/context 42))))
-  (t/is (= [] (writer/log (p/mreturn writer/context 42))))
+  (t/is (= 42 (writer/value (m/return writer/context 42))))
+  (t/is (= [] (writer/log (m/return writer/context 42))))
 
   ;; The `tell` function adds the given value to the log
   (t/is (= ["Hello" "world"]

--- a/test/cats/monad/either_spec.cljc
+++ b/test/cats/monad/either_spec.cljc
@@ -5,6 +5,7 @@
                [cats.builtin :as b]
                [cats.protocols :as p]
                [cats.monad.either :as either]
+               [cats.context :as ctx :include-macros true]
                [cats.core :as m :include-macros true])
      :clj
      (:require [clojure.test :as t]
@@ -12,6 +13,7 @@
                [cats.builtin :as b]
                [cats.protocols :as p]
                [cats.monad.either :as either]
+               [cats.context :as ctx]
                [cats.core :as m])))
 
 (t/deftest basic-operations-test
@@ -38,7 +40,7 @@
 
 (t/deftest first-monad-law-left-identity
   (t/is (= (either/right 2)
-           (m/>>= (p/mreturn either/either-monad 2) either/right))))
+           (m/>>= (p/mreturn either/context 2) either/right))))
 
 (t/deftest second-monad-law-right-identity
   (t/is (= (either/right 2)
@@ -55,18 +57,18 @@
 
 
 (def either-vector-m
-  (either/either-transformer b/vector-monad))
+  (either/either-transformer b/vector-context))
 
 (t/deftest either-transformer-tests
   (t/is (= [(either/right 2)]
-           (m/with-monad either-vector-m
+           (ctx/with-context either-vector-m
              (m/return 2))))
 
   (t/is (= [(either/right 1)
             (either/right 2)
             (either/right 2)
             (either/right 3)]
-           (m/with-monad either-vector-m
+           (ctx/with-context either-vector-m
              (m/mlet [x [(either/right 0) (either/right 1)]
                       y [(either/right 1) (either/right 2)]]
                (m/return (+ x y))))))
@@ -75,7 +77,7 @@
             (either/right 2)
             (either/right 2)
             (either/right 3)]
-           (m/with-monad either-vector-m
+           (ctx/with-context either-vector-m
              (m/mlet [x (m/lift [0 1])
                       y (m/lift [1 2])]
                (m/return (+ x y))))))
@@ -84,7 +86,7 @@
             (either/left)
             (either/right 2)
             (either/left)]
-           (m/with-monad either-vector-m
+           (ctx/with-context either-vector-m
              (m/mlet [x [(either/right 0) (either/right 1)]
                       y [(either/right 1) (either/left)]]
                (m/return (+ x y)))))))

--- a/test/cats/monad/either_spec.cljc
+++ b/test/cats/monad/either_spec.cljc
@@ -40,7 +40,7 @@
 
 (t/deftest first-monad-law-left-identity
   (t/is (= (either/right 2)
-           (m/>>= (p/mreturn either/context 2) either/right))))
+           (m/>>= (m/return either/context 2) either/right))))
 
 (t/deftest second-monad-law-right-identity
   (t/is (= (either/right 2)

--- a/test/cats/monad/exception_spec.cljc
+++ b/test/cats/monad/exception_spec.cljc
@@ -5,6 +5,7 @@
                [cats.protocols :as p]
                [cats.monad.exception :as exc :include-macros true]
                [cats.monad.either :as either]
+               [cats.context :as ctx :include-macros true]
                [cats.core :as m :include-macros true])
      :clj
      (:require [clojure.test :as t]
@@ -12,6 +13,7 @@
                [cats.protocols :as p]
                [cats.monad.exception :as exc]
                [cats.monad.either :as either]
+               [cats.context :as ctx]
                [cats.core :as m])))
 
 (t/deftest basic-operations-test
@@ -89,11 +91,11 @@
 
 (t/deftest first-monad-law-left-identity
   (t/is (= (exc/success 2)
-           (m/>>= (p/mreturn exc/exception-monad 2)
+           (m/>>= (p/mreturn exc/context 2)
                   exc/success)))
 
   (t/is (= (exc/success 2)
-           (m/>>= (p/mreturn exc/exception-monad 2)
+           (m/>>= (p/mreturn exc/context 2)
                   exc/success
                   exc/success))))
 

--- a/test/cats/monad/exception_spec.cljc
+++ b/test/cats/monad/exception_spec.cljc
@@ -91,11 +91,11 @@
 
 (t/deftest first-monad-law-left-identity
   (t/is (= (exc/success 2)
-           (m/>>= (p/mreturn exc/context 2)
+           (m/>>= (m/return exc/context 2)
                   exc/success)))
 
   (t/is (= (exc/success 2)
-           (m/>>= (p/mreturn exc/context 2)
+           (m/>>= (m/return exc/context 2)
                   exc/success
                   exc/success))))
 

--- a/test/cats/monad/identity_spec.cljc
+++ b/test/cats/monad/identity_spec.cljc
@@ -4,12 +4,14 @@
                [cats.builtin :as b]
                [cats.protocols :as p]
                [cats.monad.identity :as id]
+               [cats.context :as ctx :include-macros true]
                [cats.core :as m :include-macros true])
      :clj
      (:require [clojure.test :as t]
                [cats.builtin :as b]
                [cats.protocols :as p]
                [cats.monad.identity :as id]
+               [cats.context :as ctx]
                [cats.core :as m])))
 
 (t/deftest basic-operations-test
@@ -22,7 +24,7 @@
 
 (t/deftest first-monad-law-left-identity
   (t/is (= (id/identity 2)
-           (m/>>= (p/mreturn id/identity-monad 2) id/identity))))
+           (m/>>= (p/mreturn id/context 2) id/identity))))
 
 (t/deftest second-monad-law-right-identity
   (t/is (= (id/identity 2)
@@ -37,9 +39,9 @@
                   (fn [x] (m/>>= (id/identity (inc x))
                                  (fn [y] (id/identity (inc y)))))))))
 
-(def identity-vecotor-t (id/identity-transformer b/vector-monad))
+(def identity-vecotor-t (id/identity-transformer b/vector-context))
 
 (t/deftest identity-transformer-tests
   (t/is (= (id/identity [2])
-           (m/with-monad identity-vecotor-t
+           (ctx/with-context identity-vecotor-t
              (m/return 2)))))

--- a/test/cats/monad/identity_spec.cljc
+++ b/test/cats/monad/identity_spec.cljc
@@ -24,7 +24,7 @@
 
 (t/deftest first-monad-law-left-identity
   (t/is (= (id/identity 2)
-           (m/>>= (p/mreturn id/context 2) id/identity))))
+           (m/>>= (m/return id/context 2) id/identity))))
 
 (t/deftest second-monad-law-right-identity
   (t/is (= (id/identity 2)

--- a/test/cats/monad/maybe_spec.cljc
+++ b/test/cats/monad/maybe_spec.cljc
@@ -4,12 +4,14 @@
                [cats.builtin :as b]
                [cats.protocols :as p]
                [cats.monad.maybe :as maybe]
+               [cats.context :as ctx :include-macros true]
                [cats.core :as m :include-macros true])
      :clj
      (:require [clojure.test :as t]
                [cats.builtin :as b]
                [cats.protocols :as p]
                [cats.monad.maybe :as maybe]
+               [cats.context :as ctx]
                [cats.core :as m])))
 
 (t/deftest maybe-monad-tests
@@ -44,12 +46,12 @@
 
   (t/testing "Its identity element is Nothing"
     (t/is (= (maybe/nothing)
-             (m/with-monad maybe/maybe-monad
+             (ctx/with-context maybe/context
                (m/mempty)))))
 
   (t/testing "The first monad law: left identity"
     (t/is (= (maybe/just 2)
-             (m/>>= (p/mreturn maybe/maybe-monad 2) maybe/just))))
+             (m/>>= (p/mreturn maybe/context 2) maybe/just))))
 
   (t/testing "The second monad law: right identity"
     (t/is (= (maybe/just 2)
@@ -64,19 +66,19 @@
                     (fn [x] (m/>>= (maybe/just (inc x))
                                    (fn [y] (maybe/just (inc y))))))))))
 
-(def maybe-vector-transformer (maybe/maybe-transformer b/vector-monad))
+(def maybe-vector-transformer (maybe/maybe-transformer b/vector-context))
 
 (t/deftest maybe-transformer-tests
   (t/testing "It can be combined with the effects of other monads"
     (t/is (= [(maybe/just 2)]
-             (m/with-monad maybe-vector-transformer
+             (ctx/with-context maybe-vector-transformer
                (m/return 2))))
 
     (t/is (= [(maybe/just 1)
               (maybe/just 2)
               (maybe/just 2)
               (maybe/just 3)]
-             (m/with-monad maybe-vector-transformer
+             (ctx/with-context maybe-vector-transformer
                (m/mlet [x [(maybe/just 0) (maybe/just 1)]
                         y [(maybe/just 1) (maybe/just 2)]]
                  (m/return (+ x y))))))
@@ -85,7 +87,7 @@
               (maybe/just 2)
               (maybe/just 2)
               (maybe/just 3)]
-             (m/with-monad maybe-vector-transformer
+             (ctx/with-context maybe-vector-transformer
                (m/mlet [x (m/lift [0 1])
                         y (m/lift [1 2])]
                  (m/return (+ x y))))))
@@ -94,7 +96,7 @@
               (maybe/nothing)
               (maybe/just 2)
               (maybe/nothing)]
-             (m/with-monad maybe-vector-transformer
+             (ctx/with-context maybe-vector-transformer
                (m/mlet [x [(maybe/just 0) (maybe/just 1)]
                         y [(maybe/just 1) (maybe/nothing)]]
                  (m/return (+ x y))))))))

--- a/test/cats/monad/maybe_spec.cljc
+++ b/test/cats/monad/maybe_spec.cljc
@@ -22,8 +22,8 @@
     (t/is (= 42 (maybe/from-maybe (maybe/nothing) 42))))
 
   (t/testing "extract function"
-    (t/is (= (p/extract (maybe/just 1)) 1))
-    (t/is (= (p/extract (maybe/nothing)) nil)))
+    (t/is (= (m/extract (maybe/just 1)) 1))
+    (t/is (= (m/extract (maybe/nothing)) nil)))
 
   (t/testing "Test IDeref"
     (t/is (= nil @(maybe/nothing)))
@@ -51,7 +51,7 @@
 
   (t/testing "The first monad law: left identity"
     (t/is (= (maybe/just 2)
-             (m/>>= (p/mreturn maybe/context 2) maybe/just))))
+             (m/>>= (m/return maybe/context 2) maybe/just))))
 
   (t/testing "The second monad law: right identity"
     (t/is (= (maybe/just 2)

--- a/test/cats/runner.cljs
+++ b/test/cats/runner.cljs
@@ -31,7 +31,8 @@
    'cats.labs.state-spec
    'cats.labs.reader-spec
    'cats.labs.writer-spec
-   'cats.labs.channel-spec))
+   'cats.labs.channel-spec
+   ))
 
 (defmethod test/report [:cljs.test/default :end-run-tests]
   [m]


### PR DESCRIPTION
This is a initial work to improve the context management with first goal make the context management more decoupled from monad concept.

TODO:
- [x] Reimplement the context management making it less coupled to monad and monad transformer.
- [x] Make the with-context macro more strict, only allowing a valid context objects.
- [x] Rename all `stuff-monad` to `context` or `stuff-context`.
- [x] Add constants for context class level
- [x] Rename al protocol methods to be in the `-method` style name.
- [x] Revisit some TODOS
- [x] Revisit the state/writer/reader implementation and its api.