### PR TITLE
Add more monoids

### DIFF
--- a/src/cats/builtin.cljc
+++ b/src/cats/builtin.cljc
@@ -236,3 +236,53 @@
    (extend-type clojure.lang.PersistentArrayMap
      p/Context
      (get-context [_] map-monoid)))
+
+(def any-monoid
+  (reify
+    p/Semigroup
+    (mappend [_ sv sv']
+      (or sv sv'))
+    p/Monoid
+    (mempty [_]
+      false)))
+
+(def all-monoid
+  (reify
+    p/Semigroup
+    (mappend [_ sv sv']
+      (and sv sv'))
+    p/Monoid
+    (mempty [_]
+      true)))
+
+(def sum-monoid
+  (reify
+    p/Semigroup
+    (mappend [_ sv sv']
+      (+ sv sv'))
+    p/Monoid
+    (mempty [_]
+      0)))
+
+(def prod-monoid
+  (reify
+    p/Semigroup
+    (mappend [_ sv sv']
+      (* sv sv'))
+    p/Monoid
+    (mempty [_]
+      1)))
+
+(def string-monoid
+  (reify
+    p/Semigroup
+    (mappend [_ sv sv']
+      (str sv sv'))
+    p/Monoid
+    (mempty [_]
+      "")))
+
+(extend-type #?(:clj java.lang.String
+                :cljs js/String)
+  p/Context
+  (get-context [_] string-monoid))

--- a/src/cats/builtin.cljc
+++ b/src/cats/builtin.cljc
@@ -27,7 +27,10 @@
   "Clojure(Script) built-in types extensions."
   (:require [clojure.set :as s]
             [cats.monad.maybe :as maybe]
-            [cats.protocols :as p]))
+            [cats.protocols :as p]
+            [cats.context :as ctx]
+            [cats.data :as d]
+            [cats.core :as m]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Nil as Nothing of Maybe monad
@@ -286,3 +289,21 @@
                 :cljs js/String)
   p/Context
   (get-context [_] string-monoid))
+
+(def pair-monoid
+  (reify
+    p/Semigroup
+    (mappend [_ sv sv']
+      (d/pair
+       (m/mappend (.fst sv) (.fst sv'))
+       (m/mappend (.snd sv) (.snd sv'))))
+    p/Monoid
+    (mempty [_]
+      (d/pair
+       (p/mempty (ctx/get-current))
+       (p/mempty (ctx/get-current))))))
+
+
+(extend-type cats.data.Pair
+  p/Context
+  (get-context [_] pair-monoid))

--- a/test/cats/builtin_spec.cljc
+++ b/test/cats/builtin_spec.cljc
@@ -3,6 +3,7 @@
             [cats.protocols :as p]
             [cats.monad.maybe :as maybe]
             [cats.context :as ctx]
+            [cats.data :as d]
 
             #?(:cljs [cljs.test :as t]
                :clj [clojure.test :as t])
@@ -190,3 +191,23 @@
   (t/testing "mappend"
     (t/is (= "Hello World" (m/mappend "Hello " "World")))
     (t/is (= "abcdefghi" (m/mappend "abc" "def" "ghi")))))
+
+(t/deftest pair-monoid
+  (t/testing "mempty"
+    (ctx/with-context b/string-monoid
+      (t/is (= (d/pair "" "") (p/mempty b/pair-monoid))))
+    (ctx/with-context b/sum-monoid
+      (t/is (= (d/pair 0 0) (p/mempty b/pair-monoid)))))
+  (t/testing "mappend"
+    (t/is (= (d/pair "Hello buddy" "Hello mate")
+             (m/mappend
+              (d/pair "Hello " "Hello ")
+              (d/pair "buddy" "mate"))))
+    ;; This won't work due to explicitly set context
+    ;; (ctx/with-context b/sum-monoid
+    ;;   (t/is (= (d/pair 10 20)
+    ;;            (m/mappend
+    ;;             (d/pair 3 5)
+    ;;             (d/pair 3 5)
+    ;;             (d/pair 4 10)))))
+    ))

--- a/test/cats/builtin_spec.cljc
+++ b/test/cats/builtin_spec.cljc
@@ -2,6 +2,7 @@
   (:require [cats.builtin :as b]
             [cats.protocols :as p]
             [cats.monad.maybe :as maybe]
+            [cats.context :as ctx]
 
             #?(:cljs [cljs.test :as t]
                :clj [clojure.test :as t])
@@ -142,3 +143,50 @@
         (t/is (= @state 0))
         (t/is (= 2 (first result)))
         (t/is (= @state 1))))))
+
+(t/deftest any-monoid
+  (t/testing "mempty"
+    (ctx/with-context b/any-monoid
+      (t/is (= false (p/mempty (ctx/get-current))))))
+  (t/testing "mappend"
+    (ctx/with-context b/any-monoid
+      (t/is (false? (m/mappend false false)))
+      (t/is (true? (m/mappend true false)))
+      (t/is (true? (m/mappend false true)))
+      (t/is (true? (m/mappend true true))))))
+
+(t/deftest all-monoid
+  (t/testing "mempty"
+    (ctx/with-context b/all-monoid
+      (t/is (= true (p/mempty (ctx/get-current))))))
+  (t/testing "mappend"
+    (ctx/with-context b/all-monoid
+      (t/is (false? (m/mappend false false)))
+      (t/is (false? (m/mappend true false)))
+      (t/is (false? (m/mappend false true)))
+      (t/is (true? (m/mappend true true))))))
+
+(t/deftest sum-monoid
+  (t/testing "mempty"
+    (ctx/with-context b/sum-monoid
+      (t/is (= 0 (p/mempty (ctx/get-current))))))
+  (t/testing "mappend"
+    (ctx/with-context b/sum-monoid
+      (t/is (= 3 (m/mappend 1 2))))))
+
+(t/deftest prod-monoid
+  (t/testing "mempty"
+    (ctx/with-context b/prod-monoid
+      (t/is (= 1 (p/mempty (ctx/get-current))))))
+  (t/testing "mappend"
+    (ctx/with-context b/prod-monoid
+      (t/is (= 6 (m/mappend 1 2 3)))
+      (t/is (= (reduce * (range 1 6)) (apply m/mappend (range 1 6)))))))
+
+(t/deftest string-monoid
+  (t/testing "mempty"
+    (ctx/with-context b/string-monoid
+      (t/is (= "" (p/mempty (ctx/get-current))))))
+  (t/testing "mappend"
+    (t/is (= "Hello World" (m/mappend "Hello " "World")))
+    (t/is (= "abcdefghi" (m/mappend "abc" "def" "ghi")))))


### PR DESCRIPTION
Hi.

This should close #51, but I've got some problems with following things:

1. As soon as there are several monoid implementations for booleans and numbers, to use cats.core/mappend with these types context should be explicitly specified. Do we need to extend these types with Context protocol and set some "default" context for them, e.g. any-monoid for booleans and sum-monoid for numbers?
2. I'm not sure about correctness of my implementation of pair-monoid: mappend won't work if context is set explicitly (commented out case in pair-monoid test). Can someone give me more insight how to fix this problem?

Thanks.