### PR TITLE
Fold fixes

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -413,7 +413,6 @@ The *Foldable* is a generic abstraction for data structures that can be folded. 
 mainly on two functions: `foldl` and `foldr`. `foldl` is also known as `reduce` or `inject`
 in other mainstream programming languages.
 
-
 Both function have an identical signature and differ in how they traverse the data structure.
 Let's look at a little example using `foldl`:
 
@@ -462,20 +461,16 @@ In contrast to the `foldr` internal execution model:
 In languages with strict argument evaluation, `foldr` does not have many
 applications because when the data structure to fold grows it tends to consume all the
 stack (causing the well known stack overflow). In case of Clojure, the unique obvious
-case of using foldr is for small datastructures or lazy sequences.
+case of using foldr is for small datastructures.
 
 [source, clojure]
 ----
-(m/foldr #(cons (inc %1) %2) '() (into [] (range 100000)))
+(m/foldr #(cons (inc %1) %2) '() (range 100000))
 ;; => StackOverflowError
-
-;; The same operation but using lazyseqs works as expected
-(m/foldr #(cons (inc %1) %2) '() (map identity (range 100000)))
-;; => (1 2 3 4 ...)
 ----
 
-The *Foldable* abstraction is already implemented for cloure vectors and lazy seqs plus
-the cats maybe, either and validation types. Let see an example how it behaves with maybe:
+The *Foldable* abstraction is already implemented for cloure vectors, lazy seqs and ranges
+plus the cats maybe, either and validation types. Let see an example how it behaves with maybe:
 
 [source, clojure]
 ----
@@ -503,7 +498,6 @@ Let see an example:
   (if (zero? y)
     (maybe/nothing)
     (maybe/just (/ x y))))
-
 
 (m/foldm m-div 1 [1 2 3])
 ;; => #<Just 1/6>

--- a/src/cats/builtin.cljc
+++ b/src/cats/builtin.cljc
@@ -175,18 +175,11 @@
 
     p/Foldable
     (-foldr [ctx f z xs]
-      (let [x (first xs)
-            xs (rest xs)]
-        (if (nil? x)
-          z
-          (f x (p/-foldr ctx f z xs)))))
+      (letfn [(rf [acc v] (f v acc))]
+        (reduce rf z (reverse xs))))
 
     (-foldl [ctx f z xs]
-      (let [x (first xs)
-            xs (rest xs)]
-        (if (nil? x)
-          z
-          (p/-foldl ctx f (f z x) xs))))))
+      (reduce f z xs))))
 
 (extend-type #?(:clj clojure.lang.PersistentVector
                 :cljs cljs.core.PersistentVector)

--- a/src/cats/builtin.cljc
+++ b/src/cats/builtin.cljc
@@ -89,20 +89,14 @@
 
     p/Foldable
     (-foldr [ctx f z xs]
-      (lazy-seq
-       (let [x (first xs)
-             xs (rest xs)]
-         (if (nil? x)
-           z
-           (f x (p/-foldr ctx f z xs))))))
+      (let [x (first xs)]
+        (if (nil? x)
+          z
+          (let [xs (rest xs)]
+            (f x (p/-foldr ctx f z xs))))))
 
     (-foldl [ctx f z xs]
-      (lazy-seq
-       (let [x (first xs)
-             xs (rest xs)]
-         (if (nil? x)
-           z
-           (p/-foldl ctx f (f z x) xs)))))))
+      (reduce f z xs))))
 
 (extend-type #?(:clj  clojure.lang.LazySeq
                 :cljs cljs.core.LazySeq)

--- a/src/cats/builtin.cljc
+++ b/src/cats/builtin.cljc
@@ -104,6 +104,31 @@
   (-get-context [_] sequence-context))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Range
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(def range-context
+  (reify
+    p/ContextClass
+    (-get-level [_] ctx/+level-default+)
+
+    p/Foldable
+    (-foldr [ctx f z xs]
+      (let [x (first xs)]
+        (if (nil? x)
+          z
+          (let [xs (rest xs)]
+            (f x (p/-foldr ctx f z xs))))))
+
+    (-foldl [ctx f z xs]
+      (reduce f z xs))))
+
+(extend-type #?(:clj  clojure.lang.LongRange
+                :cljs cljs.core.Range)
+  p/Context
+  (-get-context [_] range-context))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Vector Monad
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/test/cats/builtin_spec.cljc
+++ b/test/cats/builtin_spec.cljc
@@ -156,6 +156,15 @@
         (t/is (= 2 (first result)))
         (t/is (= @state 1))))))
 
+(t/deftest range-foldable
+  (t/testing "Foldl"
+    (t/is (= [3 2 1] (m/foldl (fn [acc v] (into [v] acc)) [] (range 1 4))))
+    (t/is (= 6 (m/foldl + 0 (range 1 4)))))
+
+  (t/testing "Foldr"
+    (t/is (= [1 2 3] (m/foldr (fn [v acc] (into [v] acc)) [] (range 1 4))))
+    (t/is (= 6 (m/foldr + 0 (range 1 4))))))
+
 (t/deftest any-monoid
   (t/testing "mempty"
     (ctx/with-context b/any-monoid

--- a/test/cats/builtin_spec.cljc
+++ b/test/cats/builtin_spec.cljc
@@ -129,32 +129,21 @@
 
 (t/deftest vector-foldable
   (t/testing "Foldl"
-    (t/is (= [2 3 4] (m/foldl #(conj %1 (inc %2)) [] [1 2 3])))
+    (t/is (= [3 2 1] (m/foldl (fn [acc v] (into [v] acc)) [] [1 2 3])))
     (t/is (= 6 (m/foldl + 0 [1 2 3]))))
 
   (t/testing "Foldr"
-    (t/is (= [2 3 4] (m/foldr #(cons (inc %1) %2) [] [1 2 3])))
+    (t/is (= [1 2 3] (m/foldr (fn [v acc] (into [v] acc)) [] [1 2 3])))
     (t/is (= 6 (m/foldr + 0 [1 2 3])))))
 
 (t/deftest lazyseq-foldable
-  (letfn [(foldl-fn [state acc x]
-            (swap! state inc)
-            (conj acc (inc x)))
-          (foldr-fn [state x acc]
-            (swap! state inc)
-            (cons (inc x) acc))]
-    (t/testing "Foldl"
-      (let [state (atom 0)
-            result (m/foldl (partial foldl-fn state) [] (map identity [1 2 3 4]))]
-        (t/is (= @state 0))
-        (t/is (= 2 (first result)))
-        (t/is (= @state 4))))
-    (t/testing "Foldr"
-      (let [state (atom 0)
-            result (m/foldr (partial foldr-fn state) '() (map identity [1 2 3 4]))]
-        (t/is (= @state 0))
-        (t/is (= 2 (first result)))
-        (t/is (= @state 1))))))
+  (t/testing "Foldl"
+    (t/is (= [3 2 1] (m/foldl (fn [acc v] (into [v] acc)) [] (map identity [1 2 3]))))
+    (t/is (= 6 (m/foldl + 0 (map identity [1 2 3])))))
+
+  (t/testing "Foldr"
+    (t/is (= [1 2 3] (m/foldr (fn [v acc] (into [v] acc)) [] (map identity [1 2 3]))))
+    (t/is (= 6 (m/foldr + 0 (map identity [1 2 3]))))))
 
 (t/deftest range-foldable
   (t/testing "Foldl"


### PR DESCRIPTION
- Fix wrong implementation of foldable for lazyseq (now foldr is only for demostration purposes because is not very usefull in clojure)
- Start using clojure's reduce as foldl implementation (it is more smart and is not recursive).
- Test now checks the haskell behavior of foldr and foldl.
- Add foldable implementation for range type.