### PR TITLE
extend the Context protocol to more Manifold types

### DIFF
--- a/src/cats/labs/manifold.clj
+++ b/src/cats/labs/manifold.clj
@@ -76,3 +76,10 @@
   p/Context
   (-get-context [_] deferred-context))
 
+(extend-type manifold.deferred.SuccessDeferred
+  p/Context
+  (-get-context [_] deferred-context))
+
+(extend-type manifold.deferred.ErrorDeferred
+  p/Context
+  (-get-context [_] deferred-context))


### PR DESCRIPTION
SuccessDeferred and ErrorDeferred instances are returned by success-deferred and error-deferred, but
are separate types from Deferred, so need the Context protocol extending to them too

This permits the code below to work as expected
```
(require '[cats.core :as m])
(require '[cats.labs.manifold :as d])
@(m/mlet [v (manifold.deferred/success-deferred 10)] (m/return (+ 10 v))) ;; => 20
(ex-data (try @(m/mlet [v (manifold.deferred/error-deferred :boo)] (m/return (+ 10 v))) (catch Throwable e e))) ;; => {:error :boo}
```