### PR TITLE
add timeouts to cats.labs.manifold

### DIFF
--- a/test/cats/labs/manifold_spec.clj
+++ b/test/cats/labs/manifold_spec.clj
@@ -87,3 +87,17 @@
 
       (t/is (= (either/right 3) @r1))
       (t/is (= (either/left :foo) @r2)))))
+
+(t/deftest timeout-doesnt-time-out
+  (let [tctx (mf/timeout-deferred-context 20)
+        v (ctx/with-context tctx
+            (m/mlet [x (d/future (Thread/sleep 10) :foo)]
+              (m/return x)))]
+    (t/is (= :foo @v))))
+
+(t/deftest timeout-times-out
+  (let [tctx (mf/timeout-deferred-context 20)
+        v (ctx/with-context tctx
+            (m/mlet [x (d/future (Thread/sleep 30) :foo)]
+              (m/return x)))]
+    (t/is (thrown? java.util.concurrent.TimeoutException @v))))


### PR DESCRIPTION
extends the cats.labs.manifold/deferred-context with timeouts