### PR TITLE
set timeout values on manifold deferreds

### DIFF
--- a/test/cats/labs/manifold_spec.clj
+++ b/test/cats/labs/manifold_spec.clj
@@ -101,5 +101,11 @@
           v (ctx/with-context tctx
               (m/mlet [x (d/future (Thread/sleep 30) :foo)]
                 (m/return x)))]
-      (t/is (thrown? java.util.concurrent.TimeoutException @v)))))
+      (t/is (thrown? java.util.concurrent.TimeoutException @v))))
 
+  (t/testing "Times out with value"
+    (let [tctx (mf/deferred-context* 20 (either/left :foo))
+          v (ctx/with-context tctx
+              (m/mlet [x (d/future (Thread/sleep 30) :foo)]
+                (m/return x)))]
+      (t/is (= (either/left :foo) @v)))))


### PR DESCRIPTION
which permits the timeout `deferred-context` to be used with a
monad-transformer stack

e.g.
```
(require '[cats.core :refer [return mlet]])
(require '[cats.context :refer [with-context]])
(require '[cats.monad.either :as either])
(require '[cats.labs.manifold :as manifold])
(def dt (either/either-t (manifold/deferred-context* 100 (either/left :timeout))))

@(with-context dt (mlet [a (manifold.deferred/future (Thread/sleep 80) (either/right :foo))] (return a)))
;; => Right[:foo]

@(with-context dt (mlet [a (manifold.deferred/future (Thread/sleep 120) (either/right :foo))] (return a)))
;; => Left[:timeout]
```
so a timeout results in a `SuccessDeferred<Left>`, instead of the wrongly-typed `ErrorDeferred<TimeoutException>`