### PR TITLE
fixing error in foldable docs

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -357,7 +357,7 @@ plus the cats maybe, either and validation types. Let see an example how it beha
 [source, clojure]
 ----
 (m/foldl #(m/return (+ %1 %2)) 1 (maybe/just 1))
-;; => #<Just 1>
+;; => #<Just 2>
 
 (m/foldl #(m/return (+ %1 %2)) 1 (maybe/nothing))
 ;; => 1


### PR DESCRIPTION
`(m/foldl #(m/return (+ %1 %2)) 1 (maybe/just 1))` should return `Just 2` instead of `Just 1`