### PR TITLE
mapseq on empty collection

### DIFF
--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -538,7 +538,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn sequence
-  "Given a non-empty collection of monadic values, collect
+  "Given a collection of monadic values, collect
   their values in a seq returned in the monadic context.
 
       (require '[cats.context :as ctx]

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -557,7 +557,7 @@
   "
   [mvs]
   (if (empty? mvs)
-    (return (ctx/get-current) ())
+    (return ())
     (let [ctx (ctx/get-current (first mvs))]
       (ctx/with-context ctx
         (reduce (fn [mvs mv]

--- a/test/cats/core_spec.cljc
+++ b/test/cats/core_spec.cljc
@@ -118,19 +118,29 @@
              (m/sequence [(maybe/just 2) (maybe/just 3)])))
 
     (t/is (= (maybe/nothing)
-             (m/sequence [(maybe/just 2) (maybe/nothing)])))))
+             (m/sequence [(maybe/just 2) (maybe/nothing)]))))
 
+  (t/testing "It works with an empty collection"
+    (t/is (= (maybe/just ())
+             (ctx/with-context maybe/context
+               (m/sequence ()))))))
 
 (t/deftest mapseq-tests
   (t/testing "It works with Maybe values"
-    (t/is (= (m/mapseq maybe/just [1 2 3 4 5])
-             (maybe/just [1 2 3 4 5])))
+    (t/is (= (maybe/just [1 2 3 4 5])
+             (m/mapseq maybe/just [1 2 3 4 5])))
     (t/is (= (maybe/nothing)
              (m/mapseq (fn [v]
                          (if (odd? v)
                            (maybe/just v)
                            (maybe/nothing)))
-                       [1 2 3 4 5])))))
+                       [1 2 3 4 5]))))
+
+  (t/testing "It works with an empty collection"
+    (t/is (= (maybe/just ())
+             (ctx/with-context maybe/context
+               (m/mapseq maybe/just []))))))
+
 (t/deftest lift-m-tests
   (let [monad+ (m/lift-m 2 +)]
     (t/testing "It can lift a function to the vector monad"


### PR DESCRIPTION
Per #101, `mapseq` on an empty collection
> should return a similar empty context

And now it does! :tada:

