### PR TITLE
Remove unnecessary call to (ctx/get-current) in foldm

### DIFF
--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -728,7 +728,7 @@
   "
   ([f z xs]
    (if (empty? xs)
-     (return (ctx/get-current) z)
+     (return z)
      (let [[h & t] xs]
        (mlet [z' (f z h)]
          (if (empty? t)


### PR DESCRIPTION
Since the 1-arity `return` is defined to call the 2-arity
`return`, passing `(ctx/get-current)` as the first argument,
the `(ctx/get-current)` call here is unnecessary.