### PR TITLE
Extension of IFn

### DIFF
--- a/src/cats/builtin.cljc
+++ b/src/cats/builtin.cljc
@@ -259,6 +259,44 @@
   (-get-context [_] set-context))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Function Monad
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(def function-context
+  (reify
+    p/Context
+    (-get-level [_] ctx/+level-default+)
+
+    p/Semigroup
+    (-mappend [ctx f g] (comp f g))
+
+    p/Monoid
+    (-mempty [_] identity)
+
+    p/Functor
+    (-fmap [_ f self]
+      (comp f self))
+
+    p/Applicative
+    (-pure [_ v]
+      (constantly v))
+
+    (-fapply [_ self av]
+      (fn [x] (self x (av x))))
+
+    p/Monad
+    (-mreturn [_ v]
+      (constantly v))
+
+    (-mbind [_ self f]
+      (fn [r] ((f (self r)) r)))))
+
+(extend-type #?(:clj clojure.lang.IFn
+                :cljs cljs.core.IFn)
+  p/Contextual
+  (-get-context [_] function-context))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Monoids
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/test/cats/builtin_spec.cljc
+++ b/test/cats/builtin_spec.cljc
@@ -124,6 +124,36 @@
                       (m/>>= #{(inc x)}
                              (fn [y] #{(inc y)}))))))))
 
+(t/deftest function-monad
+  (t/testing "Forms a semigroup"
+    (t/is (= 12
+             ((m/mappend (partial * 2) inc) 5))))
+
+  (t/testing "Forms a monoid"
+    (t/is (= 6
+             (ctx/with-context b/function-context
+               ((m/mappend inc (m/mempty)) 5)))))
+
+  (t/testing "Is a functor"
+    (t/is (= "5"
+             ((m/fmap str inc) 4))))
+
+  (t/testing "The first monad law: left identity"
+    (t/is (= 5 (ctx/with-context b/set-context
+                 ((m/>>= (m/return 1) (fn [x] (partial + x))) 4)))))
+
+  (t/testing "The second monad law: right identity"
+      (t/is (= 5 ((m/>>= inc m/return) 4))))
+
+  (t/testing "The third monad law: associativity"
+    (t/is (= ((m/>>= (m/mlet [x inc
+                              y (partial * x)]
+                             (m/return y))
+                     (fn [y] (partial + y))) 5)
+             ((m/>>= inc
+                      (fn [x]
+                        (m/>>= (partial * x)
+                               (fn [y] (partial + y))))) 5)))))
 
 (t/deftest vector-foldable
   (t/testing "Foldl"


### PR DESCRIPTION
Implements semigroup, monoid, functor, applicative and monad for IFn.

I asked in #52 which semigroup. monoid implementation would be preferred but after attempting to implement Haskell's default, I'm not sure it's possible with the context system (certainly not in a nice way). So I implemented `mappend` as `comp` and `mempty` as `identity` instead which has the added advantage be being much simpler.