### PR TITLE
Fix array-map implementations for more than 8 entries

### DIFF
--- a/src/cats/builtin.cljc
+++ b/src/cats/builtin.cljc
@@ -212,6 +212,15 @@
 ;; Array Map Monad
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defn- into-array-map
+  "Used to create array-map, as (into (array-map a) b)
+  returns hash-map when number of entries is greater than 8"
+  ([a] (into-array-map a []))
+  ([a b] (->>                          ; [[:a 1] [:b 2]]   [[:c 3] [:d 4]]
+              (concat (vec a) (vec b)) ; [[:a 1] [:b 2] [:c 3] [:d 4]]
+              (apply concat)           ; [:a 1 :b 2 :c 3 :d 4]
+              (apply array-map))))     ; (array-map :a 1 :b 2 :c 3 :d 4)
+
 (def array-map-context
   (reify
     p/Context
@@ -219,7 +228,7 @@
 
     p/Semigroup
     (-mappend [_ sv sv']
-      (into sv sv'))
+      (into-array-map sv sv'))
 
     p/Monoid
     (-mempty [_]
@@ -227,14 +236,14 @@
 
     p/Functor
     (-fmap [_ f v]
-      (into (array-map) (map f v)))
+      (into-array-map (map f v)))
 
     p/Monad
     (-mreturn [_ v]
-      (into (array-map) [v]))
+      (into-array-map [v]))
 
     (-mbind [_ self f]
-      (into (array-map) (mapcat f self)))
+      (into-array-map (mapcat f self)))
 
     p/MonadZero
     (-mzero [_]
@@ -242,7 +251,7 @@
 
     p/MonadPlus
     (-mplus [_ mv mv']
-      (into mv mv'))
+      (into-array-map mv mv'))
 
     p/Foldable
     (-foldr [ctx f z xs]

--- a/test/cats/builtin_spec.cljc
+++ b/test/cats/builtin_spec.cljc
@@ -64,6 +64,15 @@
     (t/is (= (array-map :a 1 :b 2 :c 3 :d 4 :e 5)
              (m/mappend (array-map :a 1 :b 2 :c 3) (array-map :d 4 :e 5)))))
 
+  (t/testing "Is a functor"
+    (let [a (array-map 1 1, 2 4, 3 9, 4 16, ; conj would normally
+                       5 25, 6 36, 7 49,    ; keep array-map as array-map
+                       8 64, 9 81, 10 100)  ; only up to 8 elements
+          b (m/fmap (fn [[k v]] [k (* k k)])
+              (array-map 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10))]
+      (t/is (= (keys a) (keys b))) ; check order of keys
+      (t/is (= a b))))
+
   (t/testing "Forms a monoid"
     (t/is (= (array-map :a 1 :b 2 :c 3 :d 4 :e 5)
              (ctx/with-context b/array-map-context


### PR DESCRIPTION
Clojure's `conj`, `into` and the like turn array-map into hash-map when resulting size exceeds 8. This patch preserves array-map.