### PR TITLE
Functor, Monad and Foldable for any kind of map

### DIFF
--- a/src/cats/builtin.cljc
+++ b/src/cats/builtin.cljc
@@ -209,45 +209,45 @@
   (-get-context [_] vector-context))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Array Map Monad
+;; Map Monad
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def array-map-context
+(def map-context
   (reify
     p/Context
     (-get-level [_] ctx/+level-default+)
 
     p/Semigroup
     (-mappend [_ sv sv']
-      (into sv sv'))
+      (merge sv sv'))
 
     p/Monoid
     (-mempty [_]
-      (array-map))
+      {})
 
     p/Functor
     (-fmap [_ f v]
-      (into (array-map) (map f v)))
+      (into {} (map f v)))
 
     p/Monad
     (-mreturn [_ v]
-      (into (array-map) [v]))
+      (into {} [v]))
 
     (-mbind [_ self f]
-      (into (array-map) (mapcat f self)))
+      (into {} (mapcat f self)))
 
     p/MonadZero
     (-mzero [_]
-      (array-map))
+      {})
 
     p/MonadPlus
     (-mplus [_ mv mv']
-      (into mv mv'))
+      (merge mv mv'))
 
     p/Foldable
     (-foldr [ctx f z xs]
       (letfn [(rf [acc v] (f v acc))]
-        (reduce rf z (reverse xs))))
+        (reduce rf z xs)))
 
     (-foldl [ctx f z xs]
       (reduce f z xs))))
@@ -255,7 +255,17 @@
 (extend-type #?(:clj clojure.lang.PersistentArrayMap
                 :cljs cljs.core.PersistentArrayMap)
   p/Contextual
-  (-get-context [_] array-map-context))
+  (-get-context [_] map-context))
+
+(extend-type #?(:clj clojure.lang.PersistentHashMap
+                :cljs cljs.core.PersistentHashMap)
+  p/Contextual
+  (-get-context [_] map-context))
+
+(extend-type #?(:clj clojure.lang.PersistentTreeMap
+                :cljs cljs.core.PersistentTreeMap)
+  p/Contextual
+  (-get-context [_] map-context))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Set Monad
@@ -353,33 +363,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Monoids
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(def map-monoid
-  (reify
-    p/Context
-    (-get-level [_] ctx/+level-default+)
-
-    p/Semigroup
-    (-mappend [_ sv sv']
-      (merge sv sv'))
-
-    p/Monoid
-    (-mempty [_]
-      {})))
-
-(extend-type #?(:clj clojure.lang.PersistentHashMap
-                :cljs cljs.core.PersistentHashMap)
-  p/Contextual
-  (-get-context [_] map-monoid))
-
-#?(:clj
-   (extend-type clojure.lang.PersistentTreeMap
-     p/Contextual
-     (-get-context [_] map-monoid))
-   :cljs
-   (extend-type cljs.core.PersistentTreeMap
-     p/Contextual
-     (-get-context [_] map-monoid)))
 
 (def any-monoid
   (reify

--- a/test/cats/builtin_spec.cljc
+++ b/test/cats/builtin_spec.cljc
@@ -22,13 +22,42 @@
   (t/testing "extract function"
     (t/is (= (m/extract nil) nil))))
 
-(t/deftest map-tests
-  (t/testing "Map as monoid"
-    (t/is (= (m/mempty b/map-monoid) {})))
+(t/deftest map-monad
+  (t/testing "Forms a semigroup"
+    (t/is (= {:a 1 :b 2 :c 3 :d 4 :e 5}
+             (m/mappend {:a 1 :b 2 :c 3} {:d 4 :e 5}))))
 
-  (t/testing "Map as semigroup"
-    (t/is (= (m/mappend {:a 1} {:b 2}) {:a 1 :b 2}))
-    (t/is (= (m/mappend (m/mempty b/map-monoid) {:a 1}) {:a 1}))))
+  (t/testing "Is a functor"
+    (let [a {1 1, 2 4, 3 9, 4 16}
+          b (m/fmap (fn [[k v]] [k (* k k)])
+              {1 1, 2 2, 3 3, 4 4})]
+      (t/is (= a b))))
+
+  (t/testing "Forms a monoid"
+    (t/is (= {:a 1 :b 2 :c 3}
+             (ctx/with-context b/map-context
+               (m/mappend {:a 1 :b 2 :c 3} (m/mempty))))))
+
+  (t/testing "The first monad law: left identity"
+    (t/is (= {:aa 1 :bb 2 :cc 3}
+             (m/>>= {:a 0 :b 1 :c 2}
+                    (fn [[k v]]
+                      {(->> [k k] (map name) (apply str) keyword)
+                       (inc v)})))))
+
+  (t/testing "The second law: right identity"
+    (t/is (= {:a 1 :b 2 :c 3}
+             (m/>>= {:a 1 :b 2 :c 3}
+                    m/return))))
+
+  (t/testing "The third law: associativity"
+    (t/is (= (m/>>= (m/mlet [x {:a 1 :b 2 :c 3}
+                             y (let [[k v] x] {k (inc v)})]
+                      (m/return y))
+                    (fn [[k v]] {(str k k) (inc v)}))
+             (m/>>= {:a 1 :b 2 :c 3}
+                    (fn [x] (m/>>= (let [[k v] x] {k (inc v)})
+                                   (fn [[k v]] {(str k k) (inc v)}))))))))
 
 (t/deftest vector-monad
   (t/testing "Forms a semigroup"
@@ -58,36 +87,6 @@
              (m/>>= [1 2 3 4 5]
                     (fn [x] (m/>>= [(inc x)]
                                    (fn [y] [(inc y)]))))))))
-
-(t/deftest array-map-monad
-  (t/testing "Forms a semigroup"
-    (t/is (= (array-map :a 1 :b 2 :c 3 :d 4 :e 5)
-             (m/mappend (array-map :a 1 :b 2 :c 3) (array-map :d 4 :e 5)))))
-
-  (t/testing "Forms a monoid"
-    (t/is (= (array-map :a 1 :b 2 :c 3 :d 4 :e 5)
-             (ctx/with-context b/array-map-context
-               (m/mappend (array-map :a 1 :b 2 :c 3 :d 4 :e 5) (m/mempty))))))
-
-  (t/testing "The first monad law: left identity"
-    (t/is (= (array-map :aa 1 :bb 2 :cc 3 :dd 4 :ee 5)
-             (m/>>= (array-map :a 0 :b 1 :c 2 :d 3 :e 4)
-                    (fn [[k v]] (array-map (->> [k k] (map name) (apply str) keyword)
-                                           (inc v)))))))
-
-  (t/testing "The second law: right identity"
-    (t/is (= (array-map :a 1 :b 2 :c 3 :d 4 :e 5)
-             (m/>>= (array-map :a 1 :b 2 :c 3 :d 4 :e 5)
-                    m/return))))
-
-  (t/testing "The third law: associativity"
-    (t/is (= (m/>>= (m/mlet [x (array-map :a 1 :b 2 :c 3 :d 4 :e 5)
-                             y (let [[k v] x] (array-map k (inc v)))]
-                      (m/return y))
-                    (fn [[k v]] (array-map (str k k) (inc v))))
-             (m/>>= (array-map :a 1 :b 2 :c 3 :d 4 :e 5)
-                    (fn [x] (m/>>= (let [[k v] x] (array-map k (inc v)))
-                                   (fn [[k v]] (array-map (str k k) (inc v))))))))))
 
 (t/deftest sequence-monad
   (let [val->lazyseq (fn [x] (lazy-seq [x]))
@@ -196,26 +195,26 @@
 
 (t/deftest array-map-foldable
   (t/testing "Foldl"
-    (t/is (= (array-map :c 3 :b 2 :a 1)
-             (m/foldl (fn [acc [k v]] (into (array-map k v) acc))
-                      (array-map)
-                      (array-map :a 1 :b 2 :c 3))))
-    (t/is (= "a:1;b:2;c:3;d:4;"
-             (m/foldl (fn [acc [k v]] (str acc (name k) ":" v ";"))
-                      ""
-                      (array-map :a 1 :b 2 :c 3 :d 4))))
-    (t/is (= 6 (m/foldl (fn [acc [k v]] (+ acc v)) 0 (array-map :a 1 :b 2 :c 3)))))
+    (t/is (= {:a 1 :b 2 :c 3}
+             (m/foldl (fn [acc [k v]] (merge acc {k v}))
+                      {}
+                      {:a 1 :b 2 :c 3})))
+    (t/is (= #{"a:1" "b:2" "c:3" "d:4"}
+             (m/foldl (fn [acc [k v]] (conj acc (str (name k) ":" v)))
+                      #{}
+                      {:a 1 :b 2 :c 3 :d 4})))
+    (t/is (= 6 (m/foldl (fn [acc [k v]] (+ acc v)) 0 {:a 1 :b 2 :c 3}))))
 
   (t/testing "Foldr"
-    (t/is (= (array-map :a 1 :b 2 :c 3)
-             (m/foldr (fn [[k v] acc] (into (array-map k v) acc))
-                      (array-map)
-                      (array-map :a 1 :b 2 :c 3))))
-    (t/is (= "a:1;b:2;c:3;d:4;"
-             (m/foldr (fn [[k v] acc] (str (name k) ":" v ";" acc))
-                      ""
-                      (array-map :a 1 :b 2 :c 3 :d 4))))
-    (t/is (= 6 (m/foldr (fn [[k v] acc] (+ acc v)) 0 (array-map :a 1 :b 2 :c 3))))))
+    (t/is (= {:a 1 :b 2 :c 3}
+             (m/foldr (fn [[k v] acc] (merge {k v} acc))
+                      {}
+                      {:a 1 :b 2 :c 3})))
+    (t/is (= #{"a:1" "b:2" "c:3" "d:4"}
+             (m/foldr (fn [[k v] acc] (conj acc (str (name k) ":" v)))
+                      #{}
+                      {:a 1 :b 2 :c 3 :d 4})))
+    (t/is (= 6 (m/foldr (fn [[k v] acc] (+ acc v)) 0 {:a 1 :b 2 :c 3})))))
 
 (t/deftest lazyseq-foldable
   (t/testing "Foldl"


### PR DESCRIPTION
Given array-map is just an optimization for hash-maps with small number of items and preserving order is incidental, this updates Functor, Monad and Foldable implementation I did for array-map dropping constraint for key order and extending it to any kind of map.