### PR TITLE
monadic thread macros

### DIFF
--- a/test/cats/labs/sugar_spec.clj
+++ b/test/cats/labs/sugar_spec.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :as t]
             [cats.core :as m]
             [cats.monad.maybe :refer [just nothing]]
-            [cats.labs.sugar :refer [ap ap-> ap->> as-ap->]]
+            [cats.labs.sugar :refer [ap ap-> ap->> as-ap->
+                                     ->= ->>= as->=]]
             ))
 
 (t/deftest ap-example
@@ -25,3 +26,23 @@
                     (/ (just 6) $ (nothing))
                     (inc $))
            (nothing))))
+
+(t/deftest threading-macros
+  (let [linc (comp m/return inc)
+        ldec (comp m/return dec)
+        safe-div (fn [a b] (if (> b 0) (just (/ a b)) (nothing)))]
+    (t/is (= (->= (just 1)
+                  linc
+                  linc
+                  linc)
+             (just 4)))
+    (t/is (= (->>= (just 1)
+                   ldec
+                   (safe-div 5)
+                   linc)
+             (nothing)))
+    (t/is (= (as->= (just 1) $
+                    (m/return (+ 2 $ 3))
+                    (safe-div 6 $)
+                    (linc $))
+             (just 2)))))


### PR DESCRIPTION
Probably easiest to think about as a generalization of `some->` to all monads.

They're kinda cool, but I honestly had a harder time finding uses than actually writing the code. The amount of monadic functions that need composing _and_ have extra pure arguments might not be rich enough to justify more macros.

Note that `>>=` is already variadic, and even has a `m->` compatible example:

```clj
(>>= (just 1) (comp just inc) (comp just inc))
```

If these threading macros do end up being desirable, an alternative name for `m->`/`m->>` would be to pun `->=` and `->>=` in a mix of haskell and clojure convention.