### PR TITLE
`ap`, applicative "idiom brackets" sugar

### DIFF
--- a/src/cats/labs/sugar.clj
+++ b/src/cats/labs/sugar.clj
@@ -1,0 +1,31 @@
+;; Copyright (c) 2014-2015 Andrey Antukh <niwi@niwi.nz>
+;; Copyright (c) 2014-2015 Alejandro Gómez <alejandro@dialelo.com>
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions
+;; are met:
+;;
+;; 1. Redistributions of source code must retain the above copyright
+;;    notice, this list of conditions and the following disclaimer.
+;; 2. Redistributions in binary form must reproduce the above copyright
+;;    notice, this list of conditions and the following disclaimer in the
+;;    documentation and/or other materials provided with the distribution.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+;; IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+;; OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+;; IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+;; INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+;; NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+;; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+;; THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+;; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+;; THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+(ns cats.labs.sugar
+  "Experimental syntax sugar for core abstractions. Sugar that
+   proves its worthiness will graduate to the cats.core namespace."
+  (:require [cats.core :as m]))
+
+

--- a/src/cats/labs/sugar.clj
+++ b/src/cats/labs/sugar.clj
@@ -28,4 +28,39 @@
    proves its worthiness will graduate to the cats.core namespace."
   (:require [cats.core :as m]))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; applicative "idiomatic apply"
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defmacro ap
+  "Apply a pure function to applicative arguments, e.g.
+
+   (ap + (just 1) (just 2) (just 3))
+   ;; => #<Just [6]>
+   (ap str [\"hi\" \"lo\"] [\"bye\" \"woah\" \"hey\"])
+   ;; => [\"hibye\" \"hiwoah\" \"hihey\"
+          \"lobye\" \"lowoah\" \"lohey\"]
+
+   `ap` is essentially sugar for `(apply fapply (pure f) args)`,
+   but for the common case where you have a pure, uncurried,
+   possibly variadic function.
+
+   `ap` actually desugars in `alet` form:
+
+   (macroexpand-1 `(ap + (just 1) (just2)))
+   ;; => (alet [a1 (just 1) a2 (just 2)] (+ a1 a2))
+
+   That way, variadic functions Just Work, without needing to specify
+   an arity separately.
+
+   If you're familiar with Haskell, this is closest to writing
+   \"in Applicative style\": you can straightforwardly convert
+   pure function application to effectful application by with
+   some light syntax (<$> and <*> in case of Haskell, and `ap` here).
+
+   See the original Applicative paper for more inspiration:
+   http://staff.city.ac.uk/~ross/papers/Applicative.pdf"
+  [f & args]
+  (let [syms (repeatedly (count args) (partial gensym "arg"))]
+    `(m/alet [~@(interleave syms args)]
+        (~f ~@syms))))

--- a/test/cats/labs/sugar_spec.clj
+++ b/test/cats/labs/sugar_spec.clj
@@ -1,0 +1,6 @@
+(ns cats.labs.sugar-spec
+  (:require [clojure.test :as t]
+            [cats.core :as m]
+            [cats.monad.maybe :refer [just nothing]]
+            ))
+

--- a/test/cats/labs/sugar_spec.clj
+++ b/test/cats/labs/sugar_spec.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :as t]
             [cats.core :as m]
             [cats.monad.maybe :refer [just nothing]]
-            [cats.labs.sugar :refer [ap]]
+            [cats.labs.sugar :refer [ap ap-> ap->> as-ap->]]
             ))
 
 (t/deftest ap-example
@@ -10,4 +10,18 @@
            (just 6)))
   (t/is (= (ap str ["hi" "lo"] ["bye" "woah" "hey"])
            ["hibye" "hiwoah" "hihey"
-            "lobye" "lowoah" "lohey"])))
+            "lobye" "lowoah" "lohey"]))
+  (t/is (= (ap-> (just 1)
+                 inc
+                 inc)
+           (just 3)))
+  (t/is (= (ap->> (just 1)
+                  inc
+                  inc
+                  (- (just 5)))
+           (just 2)))
+  (t/is (= (as-ap-> (just 1) $
+                    (inc $)
+                    (/ (just 6) $ (nothing))
+                    (inc $))
+           (nothing))))

--- a/test/cats/labs/sugar_spec.clj
+++ b/test/cats/labs/sugar_spec.clj
@@ -2,5 +2,12 @@
   (:require [clojure.test :as t]
             [cats.core :as m]
             [cats.monad.maybe :refer [just nothing]]
+            [cats.labs.sugar :refer [ap]]
             ))
 
+(t/deftest ap-example
+  (t/is (= (ap + (just 1) (just 2) (just 3))
+           (just 6)))
+  (t/is (= (ap str ["hi" "lo"] ["bye" "woah" "hey"])
+           ["hibye" "hiwoah" "hihey"
+            "lobye" "lowoah" "lohey"])))


### PR DESCRIPTION
Essentially the "idiom brackets" from the [original Applicative paper][0] as well as the [syntax proposal for Haskell][1] that show up from time to time. Unfortunately (or fortunately, depending on who you ask),
clojure doesn't have reader macros, so we can't implement `(| |)` banana brackets.

It's actually hard to think up a good name for this that isn't silly or overly long. `ap` seems pretty clear in the clojure world, but suggestions are welcome. 

[0]: http://staff.city.ac.uk/~ross/papers/Applicative.pdf
[1]: https://ocharles.org.uk/IdiomBrackets.html