### PR TITLE
Handle infinite channels in channel fapply

### DIFF
--- a/src/cats/labs/channel.cljc
+++ b/src/cats/labs/channel.cljc
@@ -79,13 +79,7 @@
       (a/to-chan [(if (nil? v) ::nil v)]))
 
     (-fapply [mn af av]
-      (let [c (a/chan 1)]
-        (go
-          (let [af' (a/<! (a/into [] af))
-                av' (a/<! (a/into [] av))
-                ctx (p/-get-context [])]
-            (a/onto-chan c (p/-fapply ctx af' av'))))
-        c))
+      (a/map #(%1 %2) [af av]))
 
     p/Monad
     (-mreturn [_ v]


### PR DESCRIPTION
Handle infinite channels in fapply by using `core.async/map`. It has the same semantics as the previous implementation for finite channels. The differences:

- Only one of the input channels must close to close the output channel (reducing memory usage for one long-unclosed channel)
- Handles either one or both infinite channels
- Output values available as soon as both input channels have input values available (instead of waiting for both to close).

This aligns with the other changes in #136 which handle infinite channels in `mappend`.