### PR TITLE
Disallow (maybe/just nil)

### DIFF
--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -110,7 +110,7 @@
 (defn guard
   [b]
   (if b
-    (return b)
+    (return true)
     (mzero)))
 
 (defn join

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -110,7 +110,7 @@
 (defn guard
   [b]
   (if b
-    (return nil)
+    (return b)
     (mzero)))
 
 (defn join

--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -111,12 +111,10 @@
     false))
 
 (defn just
-  "A Just type constructor.
-
-  Without arguments it returns a Just instance
-  with nil as wrapped value."
-  ([] (Just. nil))
-  ([v] (Just. v)))
+  "A Just type constructor."
+  [v]
+  {:pre [(some? v)]}
+  (Just. v))
 
 (defn nothing
   "A Nothing type constructor."

--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -202,7 +202,9 @@
 
     p/Monad
     (-mreturn [_ v]
-      (just v))
+      (if (nil? v)
+        (nothing)
+        (just v)))
     (-mbind [_ mv f]
       (if (nothing? mv)
         mv


### PR DESCRIPTION
#### Update `#'cats.core.monad.maybe/just`
Remove nullary clause and add a precondition to the remaining unary clause to ensure `v` is non-nil.
Update the docsctring accordingly.

#### Update `'cats.monad.maybe`
In `-mreturn`, if `v` is `nil`, return `#<Nothing>`, otherwise `#<Just v>`.

#### Update `#'cats.core/guard`
`(return b)` instead of `(return nil)`

This is mostly so the maybe tests pass and could be very misguided.

Fixes #148.