### PR TITLE
Address reflection warnings in core types

### DIFF
--- a/src/cats/applicative/validation.cljc
+++ b/src/cats/applicative/validation.cljc
@@ -57,14 +57,14 @@
       [Object
        (equals [self other]
          (if (instance? Ok other)
-           (= v (.-v other))
+           (= v (.-v ^Ok other))
            false))]
 
       :cljs
       [cljs.core/IEquiv
        (-equiv [_ other]
          (if (instance? Ok other)
-           (= v (.-v other))
+           (= v (.-v ^Ok other))
            false))]))
 
 (deftype Fail [v]
@@ -86,14 +86,14 @@
       [Object
        (equals [self other]
          (if (instance? Fail other)
-           (= v (.-v other))
+           (= v (.-v ^Fail other))
            false))]
 
       :cljs
       [cljs.core/IEquiv
        (-equiv [_ other]
          (if (instance? Fail other)
-           (= v (.-v other))
+           (= v (.-v ^Fail other))
            false))]))
 
 (alter-meta! #'->Ok assoc :private true)
@@ -239,12 +239,12 @@
   [av]
   {:pre [(validation? av)]}
   (if (ok? av)
-    (either/right (.-v av))
-    (either/left (.-v av))))
+    (either/right (.-v ^Ok av))
+    (either/left (.-v ^Fail av))))
 
 (defn either->validation
   [ae]
   {:pre [(either/either? ae)]}
   (if (either/right? ae)
-    (ok (.-v ae))
-    (fail (.-v ae))))
+    (ok (.-v ^cats.monad.either.Right ae))
+    (fail (.-v ^cats.monad.either.Left ae))))

--- a/src/cats/context.cljc
+++ b/src/cats/context.cljc
@@ -33,7 +33,7 @@
 
 (defn throw-illegal-argument
   {:no-doc true :internal true}
-  [text]
+  [^String text]
   #?(:cljs (throw (ex-info text {}))
      :clj  (throw (IllegalArgumentException. text))))
 

--- a/src/cats/context.cljc
+++ b/src/cats/context.cljc
@@ -31,7 +31,7 @@
 (def ^:const +level-default+ 10)
 (def ^:const +level-transformer+ 100)
 
-(defn throw-ilegal-argument
+(defn throw-illegal-argument
   {:no-doc true :internal true}
   [text]
   #?(:cljs (throw (ex-info text {}))
@@ -43,7 +43,7 @@
      [ctx & body]
      `(do
         (when (not (satisfies? p/Context ~ctx))
-          (throw-ilegal-argument "The provided context does not implements Context."))
+          (throw-illegal-argument "The provided context does not implements Context."))
         (if (nil? *context*)
           (binding [*context* ~ctx]
             ~@body)
@@ -70,7 +70,7 @@
   ([]
    (if (not-nil? *context*)
      *context*
-     (throw-ilegal-argument
+     (throw-illegal-argument
       "No context is set and it can not be automatically resolved.")))
   ([param]
    (cond
@@ -84,5 +84,5 @@
      param
 
      :else
-     (throw-ilegal-argument
+     (throw-illegal-argument
       "No context is set and it can not be automatically resolved."))))

--- a/src/cats/data.cljc
+++ b/src/cats/data.cljc
@@ -64,8 +64,8 @@
      :cljs cljs.core/IEquiv)
   (#?(:clj equals :cljs -equiv) [this other]
     (if (instance? Pair other)
-      (and (= (.-fst this) (.-fst other))
-           (= (.-snd this) (.-snd other)))
+      (and (= (.-fst this) (.-fst ^Pair other))
+           (= (.-snd this) (.-snd ^Pair other)))
       false))
 
   p/Printable
@@ -100,28 +100,30 @@
     p/Semigroup
     (-mappend [_ sv sv']
       (pair
-        (p/-mappend (p/-get-context (.-fst sv)) (.-fst sv) (.-fst sv'))
-        (p/-mappend (p/-get-context (.-snd sv)) (.-snd sv) (.-snd sv'))))
+        (p/-mappend (p/-get-context (.-fst ^Pair sv))
+                    (.-fst ^Pair sv) (.-fst ^Pair sv'))
+        (p/-mappend (p/-get-context (.-snd ^Pair sv))
+                    (.-snd ^Pair sv) (.-snd ^Pair sv'))))
 
     p/Functor
     (-fmap [_ f mv]
-      (pair (.-fst mv) (f (.-snd mv))))
+      (pair (.-fst ^Pair mv) (f (.-snd ^Pair mv))))
 
     p/Bifunctor
     (-bimap [_ f g s]
-      (pair (f (.-fst s)) (g (.-snd s))))
+      (pair (f (.-fst ^Pair s)) (g (.-snd ^Pair s))))
 
     p/Foldable
     (-foldl [_ f z mv]
-      (f z (.-snd mv)))
+      (f z (.-snd ^Pair mv)))
 
     (-foldr [_ f z mv]
-      (f (.-snd mv) z))
+      (f (.-snd ^Pair mv) z))
 
     p/Traversable
     (-traverse [_ f mv]
-      (let [a (f (.-snd mv))]
-        (p/-fmap (p/-get-context a) #(pair (.-fst mv) %) a)))))
+      (let [a (f (.-snd ^Pair mv))]
+        (p/-fmap (p/-get-context a) #(pair (.-fst ^Pair mv) %) a)))))
 
 (defn pair-monoid
   "A pair monoid type constructor."
@@ -135,8 +137,8 @@
     p/Semigroup
     (-mappend [_ sv sv']
       (pair
-       (p/-mappend inner-monoid (.-fst sv) (.-fst sv'))
-       (p/-mappend inner-monoid (.-snd sv) (.-snd sv'))))
+       (p/-mappend inner-monoid (.-fst ^Pair sv) (.-fst ^Pair sv'))
+       (p/-mappend inner-monoid (.-snd ^Pair sv) (.-snd ^Pair sv'))))
 
     p/Monoid
     (-mempty [_]

--- a/src/cats/monad/either.cljc
+++ b/src/cats/monad/either.cljc
@@ -67,14 +67,14 @@
       [Object
        (equals [self other]
          (if (instance? Right other)
-           (= v (.-v other))
+           (= v (.-v ^Right other))
            false))]
 
       :cljs
       [cljs.core/IEquiv
        (-equiv [_ other]
          (if (instance? Right other)
-           (= v (.-v other))
+           (= v (.-v ^Right other))
            false))]))
 
 (deftype Left [v]
@@ -97,14 +97,14 @@
       [Object
        (equals [self other]
          (if (instance? Left other)
-           (= v (.-v other))
+           (= v (.-v ^Left other))
            false))]
 
       :cljs
       [cljs.core/IEquiv
        (-equiv [_ other]
          (if (instance? Left other)
-           (= v (.-v other))
+           (= v (.-v ^Left other))
            false))]))
 
 (alter-meta! #'->Right assoc :private true)
@@ -156,14 +156,14 @@
     p/Functor
     (-fmap [_ f s]
       (if (right? s)
-        (right (f (.-v s)))
+        (right (f (.-v ^Right s)))
         s))
 
     p/Bifunctor
     (-bimap [_ f g s]
       (if (left? s)
-        (left  (f (.-v s)))
-        (right (g (.-v s)))))
+        (left  (f (.-v ^Left s)))
+        (right (g (.-v ^Right s)))))
 
     p/Applicative
     (-pure [_ v]
@@ -171,7 +171,7 @@
 
     (-fapply [m af av]
       (if (right? af)
-        (p/-fmap m (.-v af) av)
+        (p/-fmap m (.-v ^Right af) av)
         af))
 
     p/Monad
@@ -180,7 +180,7 @@
 
     (-mbind [_ s f]
       (if (right? s)
-        (f (.-v s))
+        (f (.-v ^Right s))
         s))
 
     p/MonadZero

--- a/src/cats/monad/either.cljc
+++ b/src/cats/monad/either.cljc
@@ -324,5 +324,8 @@
      if an exception is throw return the exception as a left,
      otherwise returns the result as a right"
      [& body]
-     `(try (right ~@body)
-           (catch Exception e# (left e#)))))
+     ;; detect compilation of a cljs namespace and inject the appropriate error
+     ;; see https://groups.google.com/forum/#!topic/clojurescript/iBY5HaQda4A
+     (if (:ns &env)
+       `(try (right ~@body) (catch js/Error e# (left e#)))
+       `(try (right ~@body) (catch Exception e# (left e#))))))

--- a/src/cats/monad/exception.cljc
+++ b/src/cats/monad/exception.cljc
@@ -62,7 +62,7 @@
      (:require-macros [cats.monad.exception :refer (try-on)])))
 
 (defn throw-exception
-  [message]
+  [^String message]
   (throw (#?(:clj IllegalArgumentException.
              :cljs js/Error.)
             message)))
@@ -99,13 +99,13 @@
       [Object
        (equals [self other]
          (if (instance? Success other)
-           (= v (.-v other))
+           (= v (.-v ^Success other))
            false))]
       :cljs
       [cljs.core/IEquiv
        (-equiv [_ other]
          (if (instance? Success other)
-           (= v (.-v other))
+           (= v (.-v ^Success other))
            false))]))
 
 (deftype Failure [e]
@@ -128,14 +128,14 @@
       [Object
        (equals [self other]
          (if (instance? Failure other)
-           (= e (.-e other))
+           (= e (.-e ^Failure other))
            false))]
 
       :cljs
       [cljs.core/IEquiv
        (-equiv [_ other]
          (if (instance? Failure other)
-           (= e (.-e other))
+           (= e (.-e ^Failure other))
            false))]))
 
 (alter-meta! #'->Success assoc :private true)
@@ -237,7 +237,7 @@
   (let [result (exec-try-on func)]
     (ctx/with-context context
       (if (failure? result)
-        (recoverfn (.-e result))
+        (recoverfn (.-e ^Failure result))
         result))))
 
 #?(:clj

--- a/src/cats/monad/identity.cljc
+++ b/src/cats/monad/identity.cljc
@@ -56,14 +56,14 @@
       [Object
        (equals [self other]
          (if (instance? Identity other)
-           (= v (.-v other))
+           (= v (.-v ^Identity other))
            false))]
 
       :cljs
       [cljs.core/IEquiv
        (-equiv [_ other]
          (if (instance? Identity other)
-           (= v (.-v other))
+           (= v (.-v ^Identity other))
            false))]))
 
 (alter-meta! #'->Identity assoc :private true)
@@ -87,21 +87,21 @@
 
     p/Functor
     (-fmap [_ f iv]
-      (Identity. (f (.-v iv))))
+      (Identity. (f (.-v ^Identity iv))))
 
     p/Applicative
     (-pure [_ v]
       (Identity. v))
 
     (-fapply [_ af av]
-      (Identity. ((.-v af) (.-v av))))
+      (Identity. ((.-v ^Identity af) (.-v ^Identity av))))
 
     p/Monad
     (-mreturn [_ v]
       (Identity. v))
 
     (-mbind [_ mv f]
-      (f (.-v mv)))
+      (f (.-v ^Identity mv)))
 
     p/Printable
     (-repr [_]

--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -62,13 +62,13 @@
       [Object
        (equals [self other]
          (if (instance? Just other)
-           (= v (.-v other))
+           (= v (.-v ^Just other))
            false))]
       :cljs
       [cljs.core/IEquiv
        (-equiv [_ other]
          (if (instance? Just other)
-           (= v (.-v other))
+           (= v (.-v ^Just other))
            false))]))
 
 (deftype Nothing []

--- a/src/cats/protocols.cljc
+++ b/src/cats/protocols.cljc
@@ -44,7 +44,7 @@
 (defprotocol Printable
   "Just an abstraction for make a type printable in a platform
   independent manner."
-  (-repr [_] "Get the repl ready representation of the object."))
+  (-repr ^String [_] "Get the repl ready representation of the object."))
 
 (defprotocol Semigroup
   "A structure with an associative binary operation."

--- a/test/cats/monad/either_spec.cljc
+++ b/test/cats/monad/either_spec.cljc
@@ -9,7 +9,7 @@
                  [cats.builtin :as b]
                  [cats.protocols :as p]
                  [cats.monad.maybe :as maybe]
-                 [cats.monad.either :as either]
+                 [cats.monad.either :as either :include-macros true]
                  [cats.context :as ctx :include-macros true]
                  [cats.core :as m :include-macros true])
        (:require-macros [clojure.test.check.clojure-test :refer (defspec)])])
@@ -257,6 +257,9 @@
 
 (t/deftest try-exception-test
   (t/testing "try-either for a exceptional function"
-    (let [result (either/try-either (throw (Exception. "oh no!")))]
+    (let [result (either/try-either #?(:clj  (throw (Exception. "oh no!"))
+                                       :cljs (throw (js/Error "oh no!"))))]
       (t/is (either/left? result))
-      (t/is (= "oh no!" (.getMessage @result))))))
+      #?(:clj  (t/is (= "oh no!" (.getMessage @result)))
+         :cljs (t/is (= "oh no!" (.-message @result))))
+      )))


### PR DESCRIPTION
Reflection warnings (#152) are a symptom of a significant performance problem as runtime reflection for field lookups is expensive. Adding type hints for core types should give a significant performance improvement for hot code.

The type hints added in this commit are generally safe as they're guarded by an `instance?`, however in some cases (especially Pair) these type hints could restrict reusability, e.g. by preventing someone else from implementing their own type with the same field name, and so extending the type-class in an ad-hoc fashion. I think this trade-off is acceptable, if type-class extension is something you want to allow it would be better to add a protocol for retrieving values rather than relying on ad-hoc name matching.