### PR TITLE
when / unless macros

### DIFF
--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -196,31 +196,33 @@
   (let [ctx (ctx/infer af)]
     (reduce (partial p/-fapply ctx) af avs)))
 
-(defmacro when
-  "Given an expression and a monadic value,
+#?(:clj
+   (defmacro when
+     "Given an expression and a monadic value,
   if the expression is logical true, return the monadic value.
   Otherwise, return nil in a monadic context."
-  ([b mv]
-   `(if ~b
-      (do ~mv)
-      (cats.core/pure nil)))
-  ([ctx b mv]
-   `(if ~b
-      (do ~mv)
-      (cats.core/pure ~ctx nil))))
+     ([b mv]
+      `(if ~b
+         (do ~mv)
+         (cats.core/pure nil)))
+     ([ctx b mv]
+      `(if ~b
+         (do ~mv)
+         (cats.core/pure ~ctx nil)))))
 
-(defmacro unless
-  "Given an expression and a monadic value,
+#?(:clj
+   (defmacro unless
+     "Given an expression and a monadic value,
   if the expression is not logical true, return the monadic value.
   Otherwise, return nil in a monadic context."
-  ([b mv]
-   `(if (not ~b)
-      (do ~mv)
-      (cats.core/pure nil)))
-  ([ctx b mv]
-   `(if (not ~b)
-      (do ~mv)
-      (cats.core/pure ~ctx nil))))
+     ([b mv]
+      `(if (not ~b)
+         (do ~mv)
+         (cats.core/pure nil)))
+     ([ctx b mv]
+      `(if (not ~b)
+         (do ~mv)
+         (cats.core/pure ~ctx nil)))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -196,25 +196,32 @@
   (let [ctx (ctx/infer af)]
     (reduce (partial p/-fapply ctx) af avs)))
 
-(defn when
+(defmacro when
   "Given an expression and a monadic value,
   if the expression is logical true, return the monadic value.
   Otherwise, return nil in a monadic context."
   ([b mv]
-   (when (ctx/infer mv) b mv))
+   `(if ~b
+      (do ~mv)
+      (cats.core/pure nil)))
   ([ctx b mv]
-   (if b
-     mv
-     (pure ctx nil))))
+   `(if ~b
+      (do ~mv)
+      (cats.core/pure ~ctx nil))))
 
-(defn unless
+(defmacro unless
   "Given an expression and a monadic value,
   if the expression is not logical true, return the monadic value.
   Otherwise, return nil in a monadic context."
   ([b mv]
-   (when (not b) mv))
+   `(if (not ~b)
+      (do ~mv)
+      (cats.core/pure nil)))
   ([ctx b mv]
-   (when ctx (not b) mv)))
+   `(if (not ~b)
+      (do ~mv)
+      (cats.core/pure ~ctx nil))))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Monadic Let Macro

--- a/test/cats/core_spec.cljc
+++ b/test/cats/core_spec.cljc
@@ -203,20 +203,38 @@
 (t/deftest when-tests
   (t/testing "It returns the monadic value unchanged when the condition is true"
     (t/is (= (maybe/just 3)
-             (m/when true (maybe/just 3)))))
+             (m/when true (maybe/just 3))))
+    (t/is (= (maybe/just 3)
+             (m/when maybe/context true (maybe/just 3)))))
 
   (t/testing "It returns nil in the monadic context when the condition is false"
+    (ctx/with-context b/sequence-context
+      (t/is (= [nil]
+               (m/when false []))))
     (t/is (= [nil]
-             (m/when false [])))))
+             (m/when b/sequence-context false []))))
+
+  (t/testing "it doesn't evaluate the mv when the conditions is false"
+    (t/is (= [nil]
+             (m/when b/sequence-context false (throw (ex-info "bang" {})))))))
 
 (t/deftest unless-tests
   (t/testing "It returns the monadic value unchanged when the condition is false"
     (t/is (= (maybe/just 3)
-             (m/unless false (maybe/just 3)))))
+             (m/unless false (maybe/just 3))))
+    (t/is (= (maybe/just 3)
+             (m/unless maybe/context false (maybe/just 3)))))
 
   (t/testing "It returns nil in the monadic context when the condition is true"
+    (ctx/with-context b/sequence-context
+      (t/is (= [nil]
+               (m/unless true []))))
     (t/is (= [nil]
-             (m/unless true [])))))
+             (m/unless b/sequence-context true []))))
+
+  (t/testing "it doesn't evaluate the mv when the condition is true"
+    (t/is (= [nil]
+             (m/unless b/sequence-context true (throw (ex-info "bang" {})))))))
 
 (t/deftest curry-tests
   #?(:clj


### PR DESCRIPTION
`cats.core/when` and `cats.core/unless` are currently fns, so they evaluate the monadic value expression even when the condition is false or true respectively

this patch rewrites `cats.core/when` and `cats.core/unless` as macros and adds some more tests to check that the monadic value expression is not evaluated unless it is to be returned