### PR TITLE
Add function to the builtin types doc

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -1554,6 +1554,7 @@ the previously explained protocols.
 | vector   | Semigroup, Monoid, Functor, Applicative, Monad, MonadZero, MonadPlus, Foldable
 | hash-set | Semigroup, Monoid, Functor, Applicative, Monad, MonadZero, MonadPlus
 | hash-map | Semigroup, Monoid
+| function | Semigroup, Monoid, Functor, Applicative, Monad
 |==========================================================================================
 
 


### PR DESCRIPTION
Clojure's clojure.lang.IFn and ClojureScript's cljs.core.IFn both have several important protocols extended to them. They act like containers for a single, uncurried behavior.