### PR TITLE
Fix promesa.protocols require in cats.labs.promise

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [org.clojure/test.check "0.9.0" :scope "provided"]
                  [org.clojure/core.match "0.3.0-alpha4" :scope "provided"]
                  [manifold "0.1.5" :scope "provided"]
-                 [funcool/promesa "1.4.0" :scope "provided"]]
+                 [funcool/promesa "1.8.0" :scope "provided"]]
   :deploy-repositories {"releases"  :clojars
                         "snapshots" :clojars}
   :source-paths   ["src"]

--- a/src/cats/labs/promise.cljc
+++ b/src/cats/labs/promise.cljc
@@ -4,7 +4,7 @@
             [cats.context :as mc]
             [cats.protocols :as mp]
             [promesa.core :as p]
-            [promesa.impl.proto :as pp])
+            [promesa.protocols :as pp])
   #?(:clj
      (:import java.util.concurrent.CompletableFuture)))
 


### PR DESCRIPTION
cats.labs.promise was requiring promesa.impl.proto from promesa version 1.4.0, which breaks the build when using the current version 1.8.0, because at some point the namespace has been renamed to promesa.protocols. 