### PR TITLE
Change either monad implementation to record

### DIFF
--- a/src/cats/monad/either.cljc
+++ b/src/cats/monad/either.cljc
@@ -45,95 +45,37 @@
 
 (declare context)
 
-(deftype Right [v]
+(defrecord Right [right]
   p/Contextual
   (-get-context [_] context)
 
   p/Extract
-  (-extract [_] v)
+  (-extract [_] right)
 
   p/Printable
   (-repr [_]
-    (str "#<Right " (pr-str v) ">"))
-
-  #?@(:cljs [cljs.core/ILookup
-             (-lookup
-               [this k]
-                 (if (= k :right) @this nil))
-             (-lookup
-               [this k not-found]
-                 (if (= k :right) @this not-found))]
-      :clj  [clojure.lang.ILookup
-             (valAt
-               [this k]
-                 (if (= k :right) @this nil))
-             (valAt
-               [this k not-found]
-                 (if (= k :right) @this not-found))])
+    (str "#<Right " (pr-str right) ">"))
 
   #?@(:cljs [cljs.core/IDeref
-             (-deref [_] v)]
+             (-deref [_] right)]
       :clj  [clojure.lang.IDeref
-             (deref [_] v)])
+             (deref [_] right)]))
 
-  #?@(:clj
-      [Object
-       (equals [self other]
-         (if (instance? Right other)
-           (= v (.-v ^Right other))
-           false))]
-
-      :cljs
-      [cljs.core/IEquiv
-       (-equiv [_ other]
-         (if (instance? Right other)
-           (= v (.-v ^Right other))
-           false))]))
-
-(deftype Left [v]
+(defrecord Left [left]
   p/Contextual
   (-get-context [_] context)
 
   p/Extract
-  (-extract [_] v)
+  (-extract [_] left)
 
   p/Printable
   (-repr [_]
-    (str "#<Left " (pr-str v) ">"))
-
-  #?@(:cljs [cljs.core/ILookup
-             (-lookup
-               [this k]
-                 (if (= k :left) @this nil))
-             (-lookup
-               [this k not-found]
-                 (if (= k :left) @this not-found))]
-      :clj  [clojure.lang.ILookup
-             (valAt
-               [this k]
-                 (if (= k :left) @this nil))
-             (valAt
-               [this k not-found]
-                 (if (= k :left) @this not-found))])
+    (str "#<Left " (pr-str left) ">"))
 
   #?@(:cljs [cljs.core/IDeref
-             (-deref [_] v)]
+             (-deref [_] left)]
       :clj  [clojure.lang.IDeref
-             (deref [_] v)])
-
-  #?@(:clj
-      [Object
-       (equals [self other]
-         (if (instance? Left other)
-           (= v (.-v ^Left other))
-           false))]
-
-      :cljs
-      [cljs.core/IEquiv
-       (-equiv [_ other]
-         (if (instance? Left other)
-           (= v (.-v ^Left other))
-           false))]))
+             (deref [_] left)]))
 
 (alter-meta! #'->Right assoc :private true)
 (alter-meta! #'->Left assoc :private true)
@@ -143,13 +85,13 @@
 
 (defn left
   "A Left type constructor."
-  ([] (Left. nil))
-  ([v] (Left. v)))
+  ([] (->Left nil))
+  ([v] (->Left v)))
 
 (defn right
   "A Right type constructor."
-  ([] (Right. nil))
-  ([v] (Right. v)))
+  ([] (->Right nil))
+  ([v] (->Right v)))
 
 (defn left?
   "Return true if `v` is an instance
@@ -188,14 +130,14 @@
     p/Functor
     (-fmap [_ f s]
       (if (right? s)
-        (right (f (.-v ^Right s)))
+        (right (f (p/-extract ^Right s)))
         s))
 
     p/Bifunctor
     (-bimap [_ f g s]
       (if (left? s)
-        (left  (f (.-v ^Left s)))
-        (right (g (.-v ^Right s)))))
+        (left  (f (p/-extract ^Left s)))
+        (right (g (p/-extract ^Right s)))))
 
     p/Applicative
     (-pure [_ v]
@@ -203,7 +145,7 @@
 
     (-fapply [m af av]
       (if (right? af)
-        (p/-fmap m (.-v ^Right af) av)
+        (p/-fmap m (p/-extract ^Right af) av)
         af))
 
     p/Monad
@@ -214,7 +156,7 @@
       (assert (either? s) (str "Context mismatch: " (p/-repr s)
                                " is not allowed to use with either context."))
       (if (right? s)
-        (f (.-v ^Right s))
+        (f (p/-extract ^Right s))
         s))
 
     p/MonadZero

--- a/src/cats/monad/exception.cljc
+++ b/src/cats/monad/exception.cljc
@@ -79,7 +79,7 @@
 
 (declare context)
 
-(deftype Success [v]
+(defrecord Success [v]
   p/Contextual
   (-get-context [_] context)
 
@@ -93,22 +93,9 @@
   #?@(:cljs [cljs.core/IDeref
              (-deref [_] v)]
       :clj  [clojure.lang.IDeref
-             (deref [_] v)])
+             (deref [_] v)]))
 
-  #?@(:clj
-      [Object
-       (equals [self other]
-         (if (instance? Success other)
-           (= v (.-v ^Success other))
-           false))]
-      :cljs
-      [cljs.core/IEquiv
-       (-equiv [_ other]
-         (if (instance? Success other)
-           (= v (.-v ^Success other))
-           false))]))
-
-(deftype Failure [e]
+(defrecord Failure [e]
   p/Contextual
   (-get-context [_] context)
 
@@ -122,21 +109,7 @@
   #?@(:cljs [cljs.core/IDeref
              (-deref [_] (throw e))]
       :clj  [clojure.lang.IDeref
-             (deref [_] (throw e))])
-
-  #?@(:clj
-      [Object
-       (equals [self other]
-         (if (instance? Failure other)
-           (= e (.-e ^Failure other))
-           false))]
-
-      :cljs
-      [cljs.core/IEquiv
-       (-equiv [_ other]
-         (if (instance? Failure other)
-           (= e (.-e ^Failure other))
-           false))]))
+             (deref [_] (throw e))]))
 
 (alter-meta! #'->Success assoc :private true)
 (alter-meta! #'->Failure assoc :private true)

--- a/src/cats/monad/identity.cljc
+++ b/src/cats/monad/identity.cljc
@@ -59,6 +59,12 @@
   [v]
   (Identity. v))
 
+(defn identity?
+  "Return true in case of `v` is instance
+  of Identity monad."
+  [v]
+  (instance? Identity v))
+
 ;; --- Monad definition
 
 (def ^{:no-doc true}

--- a/src/cats/monad/identity.cljc
+++ b/src/cats/monad/identity.cljc
@@ -34,7 +34,7 @@
 
 ;; --- Type constructors
 
-(deftype Identity [v]
+(defrecord Identity [v]
   p/Contextual
   (-get-context [_] context)
 
@@ -48,21 +48,7 @@
   #?@(:cljs [cljs.core/IDeref
              (-deref [_] v)]
       :clj  [clojure.lang.IDeref
-             (deref [_] v)])
-
-  #?@(:clj
-      [Object
-       (equals [self other]
-         (if (instance? Identity other)
-           (= v (.-v ^Identity other))
-           false))]
-
-      :cljs
-      [cljs.core/IEquiv
-       (-equiv [_ other]
-         (if (instance? Identity other)
-           (= v (.-v ^Identity other))
-           false))]))
+             (deref [_] v)]))
 
 (alter-meta! #'->Identity assoc :private true)
 

--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -40,51 +40,23 @@
 
 (declare context)
 
-(deftype Just [v]
+(defrecord Just [just]
   p/Contextual
   (-get-context [_] context)
 
   p/Extract
-  (-extract [_] v)
+  (-extract [_] just)
 
   p/Printable
   (-repr [_]
-    (str "#<Just " (pr-str v) ">"))
-
-  #?@(:cljs [cljs.core/ILookup
-             (-lookup
-               [this k]
-                 (if (= k :just) @this nil))
-             (-lookup
-               [this k not-found]
-                 (if (= k :just) @this not-found))]
-      :clj  [clojure.lang.ILookup
-             (valAt
-               [this k]
-                 (if (= k :just) @this nil))
-             (valAt
-               [this k not-found]
-                 (if (= k :just) @this not-found))])
+    (str "#<Just " (pr-str just) ">"))
 
   #?@(:cljs [cljs.core/IDeref
-             (-deref [_] v)]
+             (-deref [_] just)]
       :clj  [clojure.lang.IDeref
-             (deref [_] v)])
+             (deref [_] just)]))
 
-  #?@(:clj
-      [Object
-       (equals [self other]
-         (if (instance? Just other)
-           (= v (.-v ^Just other))
-           false))]
-      :cljs
-      [cljs.core/IEquiv
-       (-equiv [_ other]
-         (if (instance? Just other)
-           (= v (.-v ^Just other))
-           false))]))
-
-(deftype Nothing []
+(defrecord Nothing []
   p/Contextual
   (-get-context [_] context)
 
@@ -95,34 +67,10 @@
   (-repr [_]
     "#<Nothing>")
 
-  #?@(:cljs [cljs.core/ILookup
-             (-lookup
-               [this k]
-                 (if (= k :nothing) this nil))
-             (-lookup
-               [this k not-found]
-                 (if (= k :nothing) this not-found))]
-      :clj  [clojure.lang.ILookup
-             (valAt
-               [this k]
-                 (if (= k :nothing) this nil))
-             (valAt
-               [this k not-found]
-                 (if (= k :nothing) this not-found))])
-
   #?@(:cljs [cljs.core/IDeref
              (-deref [_] nil)]
       :clj  [clojure.lang.IDeref
-             (deref [_] nil)])
-
-  #?@(:clj
-      [Object
-       (equals [self other]
-         (instance? Nothing other))]
-      :cljs
-      [cljs.core/IEquiv
-       (-equiv [_ other]
-         (instance? Nothing other))]))
+             (deref [_] nil)]))
 
 (alter-meta! #'->Nothing assoc :private true)
 (alter-meta! #'->Just assoc :private true)
@@ -152,7 +100,7 @@
 (defn nothing
   "A Nothing type constructor."
   []
-  (Nothing.))
+  (assoc (Nothing.) :nothing nil))
 
 (defn just?
   "Returns true if `v` is an instance

--- a/test/cats/monad/identity_spec.cljc
+++ b/test/cats/monad/identity_spec.cljc
@@ -74,3 +74,6 @@
    {:ctx id/context
     :f   (comp id/identity str)
     :g   (comp id/identity count)}))
+
+(t/deftest predicate-test
+  (t/is (id/identity 1)))


### PR DESCRIPTION
This allows us to use `clojure.spec` with it :)

```clojure
(s/def :un/right int?)
(s/def :un/left string?)
(s/def :either/spec (s/and either/either?
                           (s/or :right (s/and either/right? (s/keys :req-un [:un/right]))
                                 :left (s/and either/left? (s/keys :req-un [:un/left])))))
```

I'm still not sure how to make it compatible with generators.

I don't know if there's a good reason to use types instead of records here, but I thought doing this one first would serve as a proof of concept for refactoring other monads. 