### PR TITLE
Fix Issue #192 of dynamic context overriding default context

### DIFF
--- a/src/cats/labs/test.cljc
+++ b/src/cats/labs/test.cljc
@@ -74,7 +74,7 @@
 (defn monoid-identity-element
   [{:keys [ctx gen empty eq] :or {empty (m/mempty ctx) eq =}}]
   (prop/for-all [x gen]
-    (ctx/with-context ctx
+    (ctx/with-context-override ctx
       (eq x
           (m/mappend x empty)
           (m/mappend empty x)))))

--- a/test/cats/labs/manifold_spec.clj
+++ b/test/cats/labs/manifold_spec.clj
@@ -77,14 +77,14 @@
 
   (t/testing "Times out"
     (let [tctx (mf/deferred-context* 20)
-          v (ctx/with-context tctx
+          v (ctx/with-context-override tctx
               (m/mlet [x (d/future (Thread/sleep 30) :foo)]
                 (m/return x)))]
       (t/is (thrown? java.util.concurrent.TimeoutException @v))))
 
   (t/testing "Times out with value"
     (let [tctx (mf/deferred-context* 20 (either/left :foo))
-          v (ctx/with-context tctx
+          v (ctx/with-context-override tctx
               (m/mlet [x (d/future (Thread/sleep 30) :foo)]
                 (m/return x)))]
       (t/is (= (either/left :foo) @v)))))


### PR DESCRIPTION
This is an attempt to fix https://github.com/funcool/cats/issues/192

The issue was that when a dynamic context is set, it overrides all of the default contexts, making it get nested contexts wrong if they are not themselves set dynamically.

What I did was swapping the order of evaluation of `ctx/infer`, making the contexts inferred from `p/Contextual` take precedence over the dynamic context. If you want to override this behaviour and set a dynamic context over the `p/Contextual` default, you need to use `with-context-override` instead. It needs to be noted however, that if one does this, all possible nested different context will have to be set with `with-context-override` as well.

I don't think this fix is ideal, but is better than the way it is right now. Suggestions are welcome.