### PR TITLE
Define cats.monad.maybe/maybe as a macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,18 @@ Stable:
 
 - **Documentation:** http://funcool.github.io/cats/latest/
 - **API reference:** http://funcool.github.io/cats/latest/api/
+
+## Tests
+
+To run Clojure tests:
+
+```
+lein test
+```
+
+To run ClojureScript tests:
+
+```
+./scripts/build
+node out/tests.js
+```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Stable:
 - **Documentation:** http://funcool.github.io/cats/latest/
 - **API reference:** http://funcool.github.io/cats/latest/api/
 
-## Tests
+### Tests
 
 To run Clojure tests:
 

--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -198,9 +198,9 @@
 
 #?(:clj
    (defmacro when
-     "Given an expression and a monadic value,
-  if the expression is logical true, return the monadic value.
-  Otherwise, return nil in a monadic context."
+     "Given an expression and a monadic value, if the expression is logical
+     true, return the monadic value.  Otherwise, return nil in a monadic
+     context."
      ([b mv]
       `(if ~b
          (do ~mv)
@@ -212,9 +212,9 @@
 
 #?(:clj
    (defmacro unless
-     "Given an expression and a monadic value,
-  if the expression is not logical true, return the monadic value.
-  Otherwise, return nil in a monadic context."
+     "Given an expression and a monadic value, if the expression is not logical
+     true, return the monadic value.  Otherwise, return nil in a monadic
+     context."
      ([b mv]
       `(if (not ~b)
          (do ~mv)

--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -277,15 +277,17 @@
 
 ;; --- Utility functions
 
-(defn maybe
-  "Given a default value, a maybe and a function, return the default
-  if the maybe is a nothing; if its a just, apply the function to the
-  value it contains and return the result."
-  [default m f]
-  {:pre [(maybe? m)]}
-  (if (nothing? m)
-    default
-    (f (p/-extract m))))
+#?(:clj
+   (defmacro maybe
+     "Given a default value, a maybe and a function, return the default if the
+     maybe is a nothing; if its a just, apply the function to the value it
+     contains and return the result."
+     [default m f]
+     `(do
+        (assert (maybe? ~m) (str "'" ~m "' is not a Maybe monad"))
+        (if (nothing? ~m)
+          ~default
+          (~f (p/-extract ~m))))))
 
 (defn seq->maybe
   "Given a collection, return a nothing if its empty or a just with its

--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -32,6 +32,8 @@
       (maybe/just 1)
       ;; => #<Just [1]>
   "
+  #?(:cljs
+    (:require-macros [cats.monad.maybe :refer (maybe)]))
   (:require [cats.protocols :as p]
             [cats.context :as ctx]
             [cats.util :as util]))

--- a/src/cats/monad/maybe.cljc
+++ b/src/cats/monad/maybe.cljc
@@ -134,14 +134,10 @@
   "Return true in case of `v` is instance
   of Maybe monad."
   [v]
-  (cond
-    (or (instance? Just v) (instance? Nothing v))
-    true
-
-    (satisfies? p/Contextual v)
-    (identical? (p/-get-context v) context)
-
-    :else false))
+  (or (instance? Just v)
+      (instance? Nothing v)
+      (and (satisfies? p/Contextual v)
+           (identical? (p/-get-context v) context))))
 
 (defn just
   "A Just type constructor."

--- a/test/cats/monad/maybe_spec.cljc
+++ b/test/cats/monad/maybe_spec.cljc
@@ -26,7 +26,8 @@
                [cats.monad.maybe :as maybe]
                [cats.monad.either :as either]
                [cats.context :as ctx]
-               [cats.core :as m])))
+               [cats.core :as m])
+     (:import [java.lang.AssertionError])))
 
 ;; Generators
 
@@ -158,7 +159,9 @@
   (let [n (maybe/nothing)
         j (maybe/just 42)]
     (t/is (= 42 (maybe/maybe 42 n inc)))
-    (t/is (= 43 (maybe/maybe 42 j inc)))))
+    (t/is (= 43 (maybe/maybe 42 j inc)))
+    (t/is (thrown? AssertionError 43 (maybe/maybe 42 :not-maybe-value inc)))
+    (t/is (= 42 (maybe/maybe 42 n (throw (ex-info "shouldn't run" {})))))))
 
 (t/deftest seq-conversion-test
   (let [n (maybe/nothing)

--- a/test/cats/monad/maybe_spec.cljc
+++ b/test/cats/monad/maybe_spec.cljc
@@ -155,12 +155,13 @@
       (t/is (maybe/just? m1)))))
 
 (t/deftest maybe-test
-  (let [n (maybe/nothing)
-        j (maybe/just 42)]
+  (let [n          (maybe/nothing)
+        j          (maybe/just 42)
+        wrap-in-ex (fn [v] (do (throw (ex-info "shouldn't run" {})) v))]
     (t/is (= 42 (maybe/maybe 42 n inc)))
     (t/is (= 43 (maybe/maybe 42 j inc)))
-    (t/is (= 42 (maybe/maybe 42 n (do (throw (ex-info "shouldn't run" {}))
-                                      inc))))
+    (t/is (= 42 (maybe/maybe 42 n (wrap-in-ex inc))))
+    (t/is (= 43 (maybe/maybe (wrap-in-ex 42) j inc)))
     (t/is (thrown?
             #?(:clj  java.lang.AssertionError
                :cljs js/Error)

--- a/test/cats/monad/maybe_spec.cljc
+++ b/test/cats/monad/maybe_spec.cljc
@@ -160,7 +160,10 @@
     (t/is (= 42 (maybe/maybe 42 n inc)))
     (t/is (= 43 (maybe/maybe 42 j inc)))
     (t/is (= 42 (maybe/maybe 42 n (throw (ex-info "shouldn't run" {})))))
-    #?(:clj (t/is (thrown? java.lang.AssertionError 43 (maybe/maybe 42 :not-maybe-value inc))))))
+    (t/is (thrown?
+            #?(:clj  java.lang.AssertionError
+               :cljs js/Error)
+            43 (maybe/maybe 42 :not-maybe-value inc)))))
 
 (t/deftest seq-conversion-test
   (let [n (maybe/nothing)

--- a/test/cats/monad/maybe_spec.cljc
+++ b/test/cats/monad/maybe_spec.cljc
@@ -26,8 +26,7 @@
                [cats.monad.maybe :as maybe]
                [cats.monad.either :as either]
                [cats.context :as ctx]
-               [cats.core :as m])
-     (:import [java.lang.AssertionError])))
+               [cats.core :as m])))
 
 ;; Generators
 
@@ -160,8 +159,8 @@
         j (maybe/just 42)]
     (t/is (= 42 (maybe/maybe 42 n inc)))
     (t/is (= 43 (maybe/maybe 42 j inc)))
-    (t/is (thrown? AssertionError 43 (maybe/maybe 42 :not-maybe-value inc)))
-    (t/is (= 42 (maybe/maybe 42 n (throw (ex-info "shouldn't run" {})))))))
+    (t/is (= 42 (maybe/maybe 42 n (throw (ex-info "shouldn't run" {})))))
+    #?(:clj (t/is (thrown? java.lang.AssertionError 43 (maybe/maybe 42 :not-maybe-value inc))))))
 
 (t/deftest seq-conversion-test
   (let [n (maybe/nothing)

--- a/test/cats/monad/maybe_spec.cljc
+++ b/test/cats/monad/maybe_spec.cljc
@@ -159,7 +159,8 @@
         j (maybe/just 42)]
     (t/is (= 42 (maybe/maybe 42 n inc)))
     (t/is (= 43 (maybe/maybe 42 j inc)))
-    (t/is (= 42 (maybe/maybe 42 n (throw (ex-info "shouldn't run" {})))))
+    (t/is (= 42 (maybe/maybe 42 n (do (throw (ex-info "shouldn't run" {}))
+                                      inc))))
     (t/is (thrown?
             #?(:clj  java.lang.AssertionError
                :cljs js/Error)


### PR DESCRIPTION
`cats.monad.maybe/maybe` is currently defined as a function. This means that arguments are evaluated before the function is invoked:
```
(maybe 1 :not-a-monad (throw (ex-info "shouldn't happen" {}))) ; => Exception raised
```

By changing `maybe` to be a macro we are able to avoid this undesired argument evaluation:
```
(maybe 1 :not-a-monad (throw (ex-info "shouldn't happen" {}))) ; => 1
```

Similar in content to https://github.com/funcool/cats/pull/179

Thanks go to @francolamping for pointing this out