### PR TITLE
Improve Either monad ease-of-use within mlet

### DIFF
--- a/src/cats/core.cljc
+++ b/src/cats/core.cljc
@@ -113,6 +113,13 @@
     (return true)
     (mzero)))
 
+#?(:clj
+   (defn guard-unless
+     [b f]
+     (when-not (satisfies? p/Bifunctor (ctx/infer))
+       (throw (IllegalArgumentException. "unless must be used within bifunctor context")))
+     `(p/-breturn (ctx/infer) ~b ~f (constantly true))))
+
 (defn join
   "Remove one level of monadic structure.
   This is the same as `(bind mv identity)`."
@@ -264,6 +271,8 @@
                       :let  `(let ~r ~acc)
                       :when `(bind (guard ~r)
                                    (fn [~(gensym)] ~acc))
+                      :unless `(bind (guard-unless ~@r)
+                                     (fn [~(gensym)] ~acc))
                       `(bind ~r (fn [~l] ~acc))))
                   `(do ~@body)))))
 

--- a/src/cats/monad/either.cljc
+++ b/src/cats/monad/either.cljc
@@ -139,6 +139,11 @@
         (left  (f (p/-extract ^Left s)))
         (right (g (p/-extract ^Right s)))))
 
+    (-breturn [_ b f g]
+      (if b
+        (right (g))
+        (left (f))))
+
     p/Applicative
     (-pure [_ v]
       (right v))

--- a/src/cats/protocols.cljc
+++ b/src/cats/protocols.cljc
@@ -64,7 +64,10 @@
 
 (defprotocol Bifunctor
   "A 'Functor' of two arguments."
-  (-bimap  [btor f g bv] "Map over both arguments at the same time."))
+  (-bimap  [btor f g bv] "Map over both arguments at the same time.")
+  (-breturn [btor b f g]
+    "If the result of expression b is logical true, evaluate function g and return the result
+     wrapped in a bifunctor. Otherwise evaluate g and return the result in a bifunctor."))
 
 (defprotocol Applicative
   "The Applicative abstraction."


### PR DESCRIPTION
This PR is based on some code I wrote to clean up ```mlet``` forms when I want to short-circuit with specific ```Left``` values. I can add test coverage if this looks like something you're interested in pulling in. Here's what I changed:
-  added a function ```-breturn``` to the ```Bifunctor``` protocol. The ```Either``` monad implements the new function by evaluating the provided expression, and returning the result of one function wrapped in a ```Right``` value if the expression evaluates to true, otherwise it returns the result of the other function in a ```Left``` value.
- added a keyword ```:unless``` to ```mlet``` as a shorthand notation for the new functionality.

With the change, this:
``` clj
(defn do-stuff
  [provided-id known-id data]
  (mlet [_ (if (= provided-id known-id) (right) (left "auth failed"))
         _ (if (valid? data) (right) (left "validation failed"))
         _ (if (confirm-something-else) (right) (left "something else failed"))]
    (return "success")))
```
becomes this: 
``` clj
(defn do-stuff
  [provided-id known-id data]
  (with-context either/context
    (mlet [:unless [(= provided-id known-id) "auth failed"]
           :unless [(valid? data) "validation failed"]
           :unless [(confirm-something-else) "something else failed"]]
      (return "success"))))
```

If there's already an even better way of doing this, please do point me to it!