### PR TITLE
Update Applicative & MonadZero documentation

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -519,7 +519,7 @@ For the already familiar Maybe type the identity element is Nothing:
 (require '[cats.core :as m])
 (require '[cats.monad.maybe :as maybe])
 
-(m/mzero maybe/maybe-monad)
+(m/mzero maybe/context)
 ;; => #<Nothing>
 ----
 

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -267,7 +267,7 @@ Examples:
 ----
 (require '[cats.monad.maybe :as maybe])
 
-(pure maybe/maybe-monad 5)
+(pure maybe/context 5)
 ;; => #<Just 5>
 ----
 


### PR DESCRIPTION
`maybe/maybe-monad` is undefined in the expressions:
- ```(m/pure maybe/maybe-monad 5)```
- ```(m/mzero maybe/maybe-monad)```

Using `maybe/context` as a substitute seems to work.
