### PR TITLE
Add pair type annotations to state monad

### DIFF
--- a/src/cats/monad/state.cljc
+++ b/src/cats/monad/state.cljc
@@ -4,7 +4,8 @@
             [cats.core :as m]
             [cats.data :as d]
             [cats.protocols :as p]
-            [cats.util :as util]))
+            [cats.util :as util])
+  (:import (cats.data Pair)))
 
 (declare context)
 
@@ -73,7 +74,7 @@
 
     (-mbind [_ self f]
       (state (fn [s]
-               (let [p          ((p/-extract self) s)
+               (let [^Pair p  ((p/-extract self) s)
                      value    (.-fst p)
                      newstate (.-snd p)]
                  ((p/-extract (f value)) newstate)))))


### PR DESCRIPTION
Addresses #216 by adding a type annotation of `Pair` in state monad.

Testing: 

Before:
```clojure
user=> (set! *warn-on-reflection* true)
true
user=> (require '[clojure.test :refer [run-tests]])
nil
user=> (require 'cats.monad.state-spec)
Reflection warning, cats/monad/state.cljc:77:31 - reference to field fst can't be resolved.
Reflection warning, cats/monad/state.cljc:78:31 - reference to field snd can't be resolved.
nil
user=> (run-tests 'cats.monad.state-spec)

Testing cats.monad.state-spec

Ran 1 tests containing 10 assertions.
0 failures, 0 errors.
{:test 1, :pass 10, :fail 0, :error 0, :type :summary}
```

After:
```clojure
user=> (set! *warn-on-reflection* true)
true
user=> (require '[clojure.test :refer [run-tests]])
nil
user=> (require 'cats.monad.state-spec)
nil
user=> (run-tests 'cats.monad.state-spec)

Testing cats.monad.state-spec

Ran 1 tests containing 10 assertions.
0 failures, 0 errors.
{:test 1, :pass 10, :fail 0, :error 0, :type :summary}
```

@JAremko