### PR TITLE
Haskell-inspired monadic do notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 2.3.2
 
-Date: 2018-10-31
+Date: 2018-11-07
 
 - Introduce haskell-inspired do-let macro
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog #
 
+## Version 2.3.2
+
+Date: 2018-10-31
+
+- Introduce haskell-inspired do-let macro
+
 ## Version 2.3.1 ##
 
 Date: 2018-10-31

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject funcool/cats "2.3.1"
+(defproject funcool/cats "2.3.2"
   :description "Category Theory abstractions for Clojure"
   :url         "https://github.com/funcool/cats"
   :license {:name "BSD (2 Clause)"

--- a/test/cats/core_spec.cljc
+++ b/test/cats/core_spec.cljc
@@ -298,3 +298,36 @@
       (t/is (= (maybe/just 1)
                (ctx/with-context maybe/context
                  (m/foldm m-div 1 [])))))))
+
+(t/deftest do-let-tests
+  (t/testing "Support regular let bindings inside do-let"
+    (t/is (= (maybe/just 2)
+             (m/do-let [i (maybe/just 1)
+                        :let [i (inc i)]]
+               (m/return i)))))
+
+  (t/testing "Support :when guards inside its bindings"
+    (t/is (= (maybe/nothing)
+             (m/do-let [i (maybe/just 2)
+                        :when (> i 2)]
+               (m/return i))))
+    (t/is (= [3 4 5]
+             (m/do-let [i [1 2 3 4 5]
+                        :when (> i 2)]
+                       (m/return i)))))
+
+  (t/testing "Support one single form"
+    (t/is (= (maybe/just 2)
+             (m/do-let (maybe/just 2)))))
+
+  (t/testing "Support multiple single form"
+    (t/is (= (maybe/just 3)
+             (m/do-let (maybe/just 2)
+                       (maybe/just 3)))))
+
+  (t/testing "Bound variables are always in scope"
+    (t/is (= (maybe/just 6)
+             (m/do-let [x (maybe/just 2)]
+                       (maybe/just x)
+                       [y (maybe/just (+ 2 x))]
+                       (maybe/just (+ 2 y)))))))


### PR DESCRIPTION
  Haskell-inspired monadic do notation
   it allows one to drop the _ when  we don't need the extracted value
   Basically,
```clojure
  (do-let
    a
    b
    [c d
     e f]
    x
    y)
```

   Translates into:
```clojure
   (mlet
    [_ a
     _ b
     c d
     e f
     _ x]
    y)
```

For some monadic idioms, the stream of transformations itself is more important than the final result.
Also, sometimes there are many extracted values that we actually don't care about. For these cases, it may be more readable and clean to use a macro like `do-let` instead of `mlet` for monadic composition.