### PR TITLE
Update pair type import to work in cljc

### DIFF
--- a/src/cats/monad/state.cljc
+++ b/src/cats/monad/state.cljc
@@ -2,10 +2,10 @@
   (:refer-clojure :exclude [eval get])
   (:require [cats.context :as ctx :refer [*context*]]
             [cats.core :as m]
-            [cats.data :as d]
+            [cats.data :as d #?@(:cljs [:refer [Pair]])]
             [cats.protocols :as p]
             [cats.util :as util])
-  (:import (cats.data Pair)))
+  #?(:clj (:import (cats.data Pair))))
 
 (declare context)
 


### PR DESCRIPTION
Addresses #224 @Bost

The issue is that type imports are [different in Clojure and Clojurescript](https://github.com/clojure/clojurescript/wiki/Using-cljc#general-considerations).

- Replicated using `scripts/build` (failed as described in #224)
- Tested by calling `scripts/build` after the change -- build script succeeded; tests via `node out/tests.js` and `lein test` pass.