### PR TITLE
Allow building on jdk 10/11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "BSD (2 Clause)"
             :url  "http://opensource.org/licenses/BSD-2-Clause"}
   :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
-                 [org.clojure/clojurescript "1.9.946" :scope "provided"]
+                 [org.clojure/clojurescript "1.10.439" :scope "provided"]
                  [org.clojure/core.async "0.4.474" :scope "provided"]
                  [org.clojure/test.check "0.9.0" :scope "provided"]
                  [org.clojure/core.match "0.3.0-alpha4" :scope "provided"]


### PR DESCRIPTION
As @Bost indicated after #224 was closed, cats does not compile when using jdk 10:

```bash
$ export JAVA_HOME=`/usr/libexec/java_home -v 10"
$ ./scripts/build
Exception in thread "main" java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter, compiling:(cljs/util.cljc:1:1)
...
```

The issue is Clojurescript as of `1.9.946` uses a deprecated module, `java.xml.bind.DataTypeConverter`, which it cannot find as it has been made non-default. The latest version of Clojurescript does not have this issue:
```bash
$ git diff
...
-                 [org.clojure/clojurescript "1.9.946" :scope "provided"]
+                 [org.clojure/clojurescript "1.10.439" :scope "provided"]
...
$ git clean -dxf
...
$ ./scripts/build
...
...
... done. Elapsed 15.111055842 seconds
```

Tests pass, as well, with the newest Clojurescript version:
```bash
$ lein test
...
Ran 219 tests containing 374 assertions.
0 failures, 0 errors.

$ node out/tests.js
...
Ran 197 tests containing 340 assertions.
0 failures, 0 errors.
```

Also, jdk 11:
```bash
$ export JAVA_HOME=`/usr/libexec/java_home -v 11`
$ ./scripts/build
... done. Elapsed 24.733712635 seconds
```