### PR TITLE
Update fn name in docstrings: "run-state" -> "run"

### DIFF
--- a/src/cats/monad/state.cljc
+++ b/src/cats/monad/state.cljc
@@ -141,7 +141,7 @@
                             y (put-state (inc x))]
                        (return y)))
     (def initial-state 1)
-    (run-state computation initial-state)
+    (run computation initial-state)
   This should return something to: #<Pair [1 2]>"
   [state seed]
   ((p/-extract state) seed))
@@ -151,7 +151,7 @@
   wrapped computation and return the resultant
   value, ignoring the state.
   Equivalent to taking the first value of the pair instance
-  returned by `run-state` function."
+  returned by `run` function."
   [state seed]
   (first (run state seed)))
 
@@ -160,7 +160,7 @@
   wrapped computation and return the resultant
   state.
   Equivalent to taking the second value of the pair instance
-  returned by `run-state` function."
+  returned by `run` function."
   [state seed]
   (second (run state seed)))
 


### PR DESCRIPTION
Minor documentation change: when the state monad was re-added in https://github.com/funcool/cats/pull/210, `*-state` functions were renamed to `*` (https://github.com/funcool/cats/pull/210#issue-164197580) but it looks like `run-state` was not updated to `run` in a few docstrings.