### PR TITLE
Fix typo in cats/monad/state.clj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog #
 
+## Version 2.3.3
+
+Date: 2019-10-02
+
+- Fix typo in cats/monad/state.clj: -repr should return a string, not a regex
+
 ## Version 2.3.2
 
 Date: 2018-11-07

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject funcool/cats "2.3.2"
+(defproject funcool/cats "2.3.3"
   :description "Category Theory abstractions for Clojure"
   :url         "https://github.com/funcool/cats"
   :license {:name "BSD (2 Clause)"

--- a/src/cats/monad/state.cljc
+++ b/src/cats/monad/state.cljc
@@ -91,7 +91,7 @@
 
     p/Printable
     (-repr [_]
-      #"<State>")))
+      "#<State>")))
 
 (util/make-printable (type context))
 


### PR DESCRIPTION
- cats.monad.state/-repr should return a string, not a regex
- remove ClassCastException when printing cats.monad.state/context values