### PR TITLE
add gets context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog #
 
+## Version 2.3.4
+
+Date: 2020-02-11
+
+- gets can receive monad context as argument
+
 ## Version 2.3.3
 
 Date: 2019-10-02

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject funcool/cats "2.3.3"
+(defproject funcool/cats "2.3.4"
   :description "Category Theory abstractions for Clojure"
   :url         "https://github.com/funcool/cats"
   :license {:name "BSD (2 Clause)"

--- a/src/cats/monad/state.cljc
+++ b/src/cats/monad/state.cljc
@@ -167,9 +167,11 @@
 (defn gets
   "State monad that returns the result of applying
   a function to a state"
-  [projfn]
-  (m/mlet [s (get)]
-    (m/return (projfn s))))
+  ([projfn context]
+   (m/mlet [s (get context)]
+     (m/return (projfn s))))
+  ([projfn]
+   (gets projfn (get-context))))
 
 (defn wrap-fn
   "Wraps a (possibly side-effecting) function to a state monad"


### PR DESCRIPTION
`gets` was using `get` that assumes the default context if none is set. This adds the option of providing a custom context like the other functions do.