### PR TITLE
Fix exception monad to catch any throwable instead of only exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog #
 
+## Version 2.3.5
+
+Date: 2020-02-21
+
+- Change exception monad to catch all throwables instead of exceptions only
+
 ## Version 2.3.4
 
 Date: 2020-02-11

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject funcool/cats "2.3.4"
+(defproject funcool/cats "2.3.5"
   :description "Category Theory abstractions for Clojure"
   :url         "https://github.com/funcool/cats"
   :license {:name "BSD (2 Clause)"

--- a/src/cats/monad/exception.cljc
+++ b/src/cats/monad/exception.cljc
@@ -199,7 +199,7 @@
         (throwable? result) (failure result)
         (exception? result) result
         :else (success result)))
-    (catch #?(:clj Exception
+    (catch #?(:clj Throwable
               :cljs js/Error) e (failure e))))
 
 (defn ^{:no-doc true}

--- a/src/cats/monad/exception.cljc
+++ b/src/cats/monad/exception.cljc
@@ -73,7 +73,7 @@
   "Return true if `v` is an instance of
   the Throwable or js/Error type."
   [e]
-  (instance? #?(:clj Exception :cljs js/Error) e))
+  (instance? #?(:clj Throwable :cljs js/Error) e))
 
 ;; --- Types and implementations.
 


### PR DESCRIPTION
> The Throwable class is the superclass of all errors and exceptions in the Java language. 