### PR TITLE
Update Promesa dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog #
 
+## Version 2.3.6
+
+Date: 2020-04-07
+
+- Bump Promesa version from 1.9.0 to 5.1.0
+
 ## Version 2.3.5
 
 Date: 2020-02-21

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [org.clojure/test.check "0.9.0" :scope "provided"]
                  [org.clojure/core.match "0.3.0-alpha4" :scope "provided"]
                  [manifold "0.1.6" :scope "provided"]
-                 [funcool/promesa "1.9.0" :scope "provided"]]
+                 [funcool/promesa "5.1.0" :scope "provided"]]
   :deploy-repositories {"releases"  :clojars
                         "snapshots" :clojars}
   :source-paths   ["src"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject funcool/cats "2.3.5"
+(defproject funcool/cats "2.3.6"
   :description "Category Theory abstractions for Clojure"
   :url         "https://github.com/funcool/cats"
   :license {:name "BSD (2 Clause)"

--- a/test/cats/labs/promise_spec.cljc
+++ b/test/cats/labs/promise_spec.cljc
@@ -4,31 +4,21 @@
                      [cats.context :as ctx :include-macros true]
                      [cats.core :as m :include-macros true]
                      [cats.labs.promise :as pm]
-                     [promesa.core :as p])
+                     [promesa.core :as p]
+                     [promesa.impl :as pi]
+                     [promesa.exec :as pe])
      :clj  (:require [clojure.test :as t]
                      [cats.builtin :as b]
                      [cats.context :as ctx]
                      [cats.core :as m]
                      [cats.labs.promise :as pm]
-                     [promesa.core :as p])))
+                     [promesa.core :as p]
+                     [promesa.exec :as pe])))
 
 
 (defn future-ok
   [sleep value]
-  (p/promise (fn [resolve reject]
-               (p/schedule sleep #(resolve value)))))
-
-(defn future-fail
-  [sleep value]
-  (p/promise (fn [_ reject]
-               (p/schedule sleep #(reject value)))))
-
-
-#?(:cljs
-   (t/deftest extract-from-rejected-promise
-     (let [p1 (p/rejected 42)]
-       (t/is (p/rejected? p1))
-       (t/is (= (p/extract p1) 42)))))
+  (p/delay sleep value))
 
 (t/deftest chaining-using-bind
   #?(:cljs


### PR DESCRIPTION
Bumps the version of Promesa depended on by `cats` to the latest release (5.1.0) to enable users of `cats` to also use the latest version of `promesa`.

Resolves issues #230 

The two biggest changes in Promesa effecting `cats` were:

1. Promesa now allows for a configurable promise type in Javascript environments.

   I’ve used the same “define a fn to extend the implementation class, call it on the default class” pattern as used in `promesa.impl` to add implementations of the `Contextual` and `Extract` protocols.
2. The protocol fn `-catch` has been removed, replaced by `-mapErr` and `-thenErr`.

   I’ve replaced the use of `-catch` with `-thenErr` (as promise flattening in an error handler seems more appropriate than not.)