### PR TITLE
add cats.core/for macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog #
 
+## Version 2.4.0
+
+Date: 2020-11-03
+
+- Add `cats.core/for` macro
+
 ## Version 2.3.6
 
 Date: 2020-04-07

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject funcool/cats "2.3.6"
+(defproject funcool/cats "2.4.0"
   :description "Category Theory abstractions for Clojure"
   :url         "https://github.com/funcool/cats"
   :license {:name "BSD (2 Clause)"

--- a/test/cats/core_spec.cljc
+++ b/test/cats/core_spec.cljc
@@ -331,3 +331,10 @@
                        (maybe/just x)
                        [y (maybe/just (+ 2 x))]
                        (maybe/just (+ 2 y)))))))
+
+(t/deftest for-tests
+  (t/testing "m/for works like (m/sequence (clojure.core/for))"
+    (t/is (= (maybe/just [2 3])
+             (m/sequence [(maybe/just 2) (maybe/just 3)])
+             (m/sequence (for [x [2 3]] (maybe/just x)))
+             (m/for [x [2 3]] (maybe/just x))))))


### PR DESCRIPTION
This adds a `for` macro to `cats.core`, which is a syntax wrapper for `(cats.core/sequence (clojure.core/for [,,,] mv))`.